### PR TITLE
Exercising dunolint invariant checking in CI

### DIFF
--- a/lib/dune_project_linter/src/dune
+++ b/lib/dune_project_linter/src/dune
@@ -19,9 +19,9 @@
   base
   dunolint
   dunolinter
-  file-rewriter
   fpath
   fpath-base
+  file-rewriter
   loc
   pp
   pp-log.err

--- a/lib/dunolinter/test/dune
+++ b/lib/dunolinter/test/dune
@@ -28,7 +28,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -allow-let-operators -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators))
  (preprocess
   (pps
    -unused-code-warnings=force


### PR DESCRIPTION
This is a dummy commit that I use to illustrate that the CI is catching when dunolint invariants are not verified.

DO NOT MERGE
