### PR TITLE
Disable macos 5.3 in the CI for now

### DIFF
--- a/.github/workflows/more-ci.yml
+++ b/.github/workflows/more-ci.yml
@@ -33,6 +33,9 @@ jobs:
           # We exclude the combination already tested in the 'ci' workflow.
           - os: ubuntu-latest
             ocaml-compiler: 5.3.x
+          # We exclude macos-5.3 - this fails when building core_unix.
+          - os: macos-latest
+            ocaml-compiler: 5.3.x
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This always fails, and I find this is a source of distraction for the time being.