### PR TITLE
Enable macos in ci

### DIFF
--- a/.github/workflows/more-ci.yml
+++ b/.github/workflows/more-ci.yml
@@ -33,9 +33,6 @@ jobs:
           # We exclude the combination already tested in the 'ci' workflow.
           - os: ubuntu-latest
             ocaml-compiler: 5.3.x
-          # We exclude macos-5.3 - this fails when building core_unix.
-          - os: macos-latest
-            ocaml-compiler: 5.3.x
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Macos with 5.3 has been disabled because of a dependency issue.

We can revisit and try to re-run the ci of this PR from time to time to monitor progress.