### PR TITLE
Attempt to pin previous odoc version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -339,6 +339,10 @@
     (< v0.18)))
   (ppxlib
    (>= 0.35.0))
+  (odoc
+   (and
+    :with-doc
+    (= 2.4.4)))
   (sexplib0
    (and
     (>= v0.17)

--- a/dunolint-dev.opam
+++ b/dunolint-dev.opam
@@ -41,11 +41,11 @@ depends: [
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.35.0"}
+  "odoc" {with-doc & = "2.4.4"}
   "sexplib0" {>= "v0.17" & < "v0.18"}
   "sexps-rewriter" {>= "0.0.3"}
   "stdio" {>= "v0.17" & < "v0.18"}
   "sherlodoc" {with-doc & >= "0.2"}
-  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Currently having a build issue with odoc version `3.0.0`.

See also #28 