### PR TITLE
Fix for odoc 3.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -342,7 +342,7 @@
   (odoc
    (and
     :with-doc
-    (= 2.4.4)))
+    (>= 2.4.4)))
   (sexplib0
    (and
     (>= v0.17)

--- a/dunolint-dev.opam
+++ b/dunolint-dev.opam
@@ -41,7 +41,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.35.0"}
-  "odoc" {with-doc & = "2.4.4"}
+  "odoc" {with-doc & >= "2.4.4"}
   "sexplib0" {>= "v0.17" & < "v0.18"}
   "sexps-rewriter" {>= "0.0.3"}
   "stdio" {>= "v0.17" & < "v0.18"}

--- a/lib/dunolint/src/dune0/pp__name.mli
+++ b/lib/dunolint/src/dune0/pp__name.mli
@@ -19,7 +19,7 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.         *)
 (*_********************************************************************************)
 
-type t
+type t (** @canonical Dunolint.Dune.Pp.Name.t *)
 
 include Container_key.S with type t := t
 include Validated_string.S with type t := t

--- a/lib/dunolinter/src/sexp_handler.mli
+++ b/lib/dunolinter/src/sexp_handler.mli
@@ -95,7 +95,7 @@ val get_args
     not present in the existing [fields]. For those that are already present,
     it will be necessary to merge them with the expected value, see the
     [rewrite] functions of the module that corresponds to that particular
-    field. For example: {!Dune_linter.Library.rewrite}. *)
+    field. For example: [Dune_linter.Library.rewrite]. *)
 val insert_new_fields
   :  sexps_rewriter:Sexps_rewriter.t
   -> indicative_field_ordering:string list


### PR DESCRIPTION
Fixes #28 

This is applying a fix according to the discussion in https://github.com/ocaml/odoc/issues/1334

This relaxes the constraint on `odoc` in the opam file, which should permit the CI to run with `odoc.3.0.0`.

Thank you @jonludlam !