### PR TITLE
Add support for library mode melange

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 
 ### Fixed
 
-- Add missing `melange` library mode (#43, @mbarbin, reported by @arvidj).
+- Add missing `melange` library mode (#43, #44, @mbarbin, reported by @arvidj).
 - Fixes for `odoc.3.0.0` (#28, #32, @mbarbin, with help from @jonludlam)
 
 ### Removed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Add missing `melange` library mode (#43, @mbarbin, reported by @arvidj).
 - Fixes for `odoc.3.0.0` (#28, #32, @mbarbin, with help from @jonludlam)
 
 ### Removed

--- a/doc/docs/reference/config/dune.md
+++ b/doc/docs/reference/config/dune.md
@@ -352,10 +352,10 @@ Stanza:
 
 The compilation modes supported are
 ```pre
-MODE := best | byte | native
+MODE := byte | native | best | melange
 ```
 
-Compilation modes are ordered by *dunolint* as: `best < byte < native`.
+Compilation modes are ordered by *dunolint* as: `byte < native < best < melange`.
 
 The predicates of the `modes` selector are:
 

--- a/lib/dune_linter/test/test__library__modes.ml
+++ b/lib/dune_linter/test/test__library__modes.ml
@@ -89,7 +89,7 @@ let%expect_test "sort" =
   (* The order in use to write the values is deterministic and the values are
      sorted by dunolint when the field is linted. *)
   rewrite {| (modes best native byte) |};
-  [%expect {| (modes best byte native) |}];
+  [%expect {| (modes byte native best) |}];
   ()
 ;;
 
@@ -177,7 +177,7 @@ let%expect_test "enforce" =
   enforce t [ has_mode `native ];
   [%expect {| (modes native) |}];
   enforce t [ has_mode `best ];
-  [%expect {| (modes best native) |}];
+  [%expect {| (modes native best) |}];
   enforce t [ not_ (has_mode `best) ];
   [%expect {| (modes native) |}];
   enforce t [ not_ (has_mode `native) ];

--- a/lib/dunolint/src/dune0/compilation_mode.ml
+++ b/lib/dunolint/src/dune0/compilation_mode.ml
@@ -24,8 +24,18 @@ module T = struct
     [ `byte
     | `native
     | `best
+    | `melange
     ]
-  [@@deriving compare, hash, sexp]
+  [@@deriving hash, sexp]
+
+  let to_comparable_int = function
+    | `byte -> 0
+    | `native -> 1
+    | `best -> 2
+    | `melange -> 3
+  ;;
+
+  let compare a b = Int.compare (to_comparable_int a) (to_comparable_int b)
 end
 
 include T

--- a/lib/dunolint/src/dune0/compilation_mode.mli
+++ b/lib/dunolint/src/dune0/compilation_mode.mli
@@ -26,6 +26,7 @@ type t =
   [ `byte
   | `native
   | `best
+  | `melange
   ]
 
 include Container_key.S with type t := t

--- a/lib/dunolint/test/test__dune__library__modes.ml
+++ b/lib/dunolint/test/test__dune__library__modes.ml
@@ -27,11 +27,13 @@ let%expect_test "predicate" =
   [%expect {| (equals ()) |}];
   test (equals (Dune.Library.Modes.of_list [ `best ]));
   [%expect {| (equals (best)) |}];
-  test (equals (Dune.Library.Modes.of_list [ `byte; `native ]));
-  [%expect {| (equals (byte native)) |}];
+  test (equals (Dune.Library.Modes.of_list [ `byte; `native; `melange ]));
+  [%expect {| (equals (byte native melange)) |}];
   test (has_mode `byte);
   [%expect {| (has_mode byte) |}];
   test (has_mode `native);
   [%expect {| (has_mode native) |}];
+  test (has_mode `melange);
+  [%expect {| (has_mode melange) |}];
   ()
 ;;


### PR DESCRIPTION
Fixes #43 

This adds `melange` in the list of supported values for the library modes stanza, such as in:

```lisp
(library
 (modes melange))
```

Reported by @arvidj - Thanks!