### PR TITLE
Reduce config libs ppx

### DIFF
--- a/.github/workflows/config-libs-ci.yml
+++ b/.github/workflows/config-libs-ci.yml
@@ -1,0 +1,59 @@
+# This workflow compiles only a subset of the packages that is meant
+# to be containing only what users needs to define a dunolint config.
+#
+# It is very closed to 'more-ci.yml' job, except it includes more
+# ocaml versions and only build certain packages.
+
+name: config-libs-ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**" # This will match pull requests targeting any branch
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+        ocaml-compiler:
+          - 5.3.x
+          - 5.2.x
+        exclude:
+          # We exclude the combination already tested in the 'ci' workflow.
+          - os: ubuntu-latest
+            ocaml-compiler: 5.3.x
+          # We exclude macos-5.3 - this fails when building core_unix.
+          - os: macos-latest
+            ocaml-compiler: 5.3.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-repositories: |
+            default: https://github.com/ocaml/opam-repository.git
+            mbarbin: https://github.com/mbarbin/opam-repository.git
+      #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
+      #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
+
+      # We build and run tests for a subset of packages. More tests are run in
+      # the development workflow and as part of the main CI job. These are the
+      # tests that are checked for every combination of os and ocaml-compiler.
+      - name: Install dependencies
+        run: opam install ./dunolint-lib.opam --deps-only --with-test
+
+      - name: Build & Run tests
+        run: opam exec -- dune build @all @runtest -p dunolint-lib

--- a/.github/workflows/config-libs-ci.yml
+++ b/.github/workflows/config-libs-ci.yml
@@ -43,6 +43,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: true
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git
             mbarbin: https://github.com/mbarbin/opam-repository.git

--- a/dune-project
+++ b/dune-project
@@ -39,23 +39,7 @@
    (and
     (>= v0.17)
     (< v0.18)))
-  (ppx_hash
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_here
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_let
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (ppx_sexp_conv
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_sexp_value
    (and
     (>= v0.17)
     (< v0.18)))

--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,7 @@
  (synopsis "A library to create dunolint configs")
  (depends
   (ocaml
-   (>= 5.3))
+   (>= 5.2))
   (base
    (and
     (>= v0.17)

--- a/dunolint-lib.opam
+++ b/dunolint-lib.opam
@@ -9,7 +9,7 @@ doc: "https://mbarbin.github.io/dunolint/"
 bug-reports: "https://github.com/mbarbin/dunolint/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml" {>= "5.3"}
+  "ocaml" {>= "5.2"}
   "base" {>= "v0.17" & < "v0.18"}
   "fpath-base" {>= "0.2.2"}
   "ppx_compare" {>= "v0.17" & < "v0.18"}

--- a/dunolint-lib.opam
+++ b/dunolint-lib.opam
@@ -14,11 +14,7 @@ depends: [
   "fpath-base" {>= "0.2.2"}
   "ppx_compare" {>= "v0.17" & < "v0.18"}
   "ppx_enumerate" {>= "v0.17" & < "v0.18"}
-  "ppx_hash" {>= "v0.17" & < "v0.18"}
-  "ppx_here" {>= "v0.17" & < "v0.18"}
-  "ppx_let" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
-  "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.35.0"}
   "re" {>= "1.8.0"}
   "sexplib0" {>= "v0.17" & < "v0.18"}

--- a/lib/dunolint/src/.ocamlformat
+++ b/lib/dunolint/src/.ocamlformat
@@ -1,0 +1,4 @@
+version=0.27.0
+ocaml-version=5.2
+profile=janestreet
+parse-docstrings=true

--- a/lib/dunolint/src/dune
+++ b/lib/dunolint/src/dune
@@ -22,14 +22,6 @@
  (lint
   (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
-  (pps
-   -unused-code-warnings=force
-   ppx_compare
-   ppx_enumerate
-   ppx_hash
-   ppx_here
-   ppx_let
-   ppx_sexp_conv
-   ppx_sexp_value)))
+  (pps -unused-code-warnings=force ppx_compare ppx_enumerate ppx_sexp_conv)))
 
 (include_subdirs qualified)

--- a/lib/dunolint/src/dune0/compilation_mode.ml
+++ b/lib/dunolint/src/dune0/compilation_mode.ml
@@ -26,7 +26,7 @@ module T = struct
     | `best
     | `melange
     ]
-  [@@deriving enumerate, hash, sexp]
+  [@@deriving enumerate, sexp]
 
   let to_comparable_int = function
     | `byte -> 0
@@ -41,4 +41,5 @@ end
 include T
 include Comparable.Make (T)
 
+let hash : t -> int = Stdlib.Hashtbl.hash
 let seeded_hash : int -> t -> int = Stdlib.Hashtbl.seeded_hash

--- a/lib/dunolint/src/linted_file_kind.ml
+++ b/lib/dunolint/src/linted_file_kind.ml
@@ -24,7 +24,7 @@ module T = struct
     [ `dune
     | `dune_project
     ]
-  [@@deriving compare, enumerate, hash, sexp]
+  [@@deriving compare, enumerate, sexp]
 
   let to_string = function
     | `dune -> "dune"
@@ -41,4 +41,5 @@ end
 include T
 include Comparable.Make (T)
 
+let hash : t -> int = Stdlib.Hashtbl.hash
 let seeded_hash : int -> t -> int = Stdlib.Hashtbl.seeded_hash

--- a/test/cram/bin/dune
+++ b/test/cram/bin/dune
@@ -1,5 +1,7 @@
 (executable
  (name lint_file_config_gen)
+ (public_name lint_file_config_gen)
+ (package dunolint-tests)
  (flags
   :standard
   -w

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -8,4 +8,6 @@
   (glob_files *.sexp)))
 
 (rule
- (copy ./bin/lint_file_config_gen.exe lint_file_config_gen.exe))
+ (package dunolint-tests)
+ (action
+  (copy ./bin/lint_file_config_gen.exe lint_file_config_gen.exe)))

--- a/vendor/blang/blang.ml
+++ b/vendor/blang/blang.ml
@@ -46,7 +46,7 @@ module T : sig
     | Not of 'a t
     | If of 'a t * 'a t * 'a t
     | Base of 'a
-  [@@deriving compare, equal, hash]
+  [@@deriving compare, equal]
 
   val invariant : 'a t -> unit
   val true_ : 'a t
@@ -65,7 +65,7 @@ end = struct
     | Not of 'a t
     | If of 'a t * 'a t * 'a t
     | Base of 'a
-  [@@deriving compare, equal, hash]
+  [@@deriving compare, equal]
 
   let invariant =
     let subterms = function
@@ -153,7 +153,7 @@ module Stable = struct
       | Not of 'a t
       | If of 'a t * 'a t * 'a t
       | Base of 'a
-    [@@deriving compare, equal, hash, sexp]
+    [@@deriving compare, equal, sexp]
 
     (* the remainder of this signature consists of functions used in the
        definitions of sexp conversions that are also useful more generally *)
@@ -175,7 +175,7 @@ module Stable = struct
     include (
       T :
         sig
-          type 'a t [@@deriving compare, equal, hash]
+          type 'a t [@@deriving compare, equal]
         end
         with type 'a t := 'a t)
 
@@ -211,7 +211,10 @@ module Stable = struct
        quadratic behavior with [andalso] or [orelse], respectively. *)
     let and_ ts = List.fold_right ts ~init:true_ ~f:andalso
     let or_ ts = List.fold_right ts ~init:false_ ~f:orelse
-    let of_sexp_error str sexp = raise_s [%sexp (str : string), (sexp : Sexp.t)]
+
+    let of_sexp_error str sexp =
+      raise_s (Sexp.List [ Atom (str : string); (sexp : Sexp.t) ])
+    ;;
 
     let unary name args sexp =
       match args with

--- a/vendor/blang/blang.mli
+++ b/vendor/blang/blang.mli
@@ -108,7 +108,7 @@ type +'a t = private
   | Not of 'a t
   | If of 'a t * 'a t * 'a t
   | Base of 'a
-[@@deriving compare, equal, hash, sexp]
+[@@deriving compare, equal, sexp]
 
 (** [Raw] provides the automatically derived [sexp_of_t], useful in debugging
     the actual structure of the blang. *)
@@ -272,6 +272,6 @@ module Stable : sig
       | Not of 'a t
       | If of 'a t * 'a t * 'a t
       | Base of 'a
-    [@@deriving compare, equal, hash, sexp]
+    [@@deriving compare, equal, sexp]
   end
 end

--- a/vendor/blang/dune
+++ b/vendor/blang/dune
@@ -5,10 +5,4 @@
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Base)
  (libraries base)
  (preprocess
-  (pps
-   -unused-code-warnings=force
-   ppx_compare
-   ppx_enumerate
-   ppx_hash
-   ppx_sexp_conv
-   ppx_sexp_value)))
+  (pps -unused-code-warnings=force ppx_compare ppx_enumerate ppx_sexp_conv)))


### PR DESCRIPTION
Explore what ppx can be removed from the transitive dependencies of the config libraries.

Related to #50 .