### PR TITLE
Add a pre-commit hook configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+---
+- id: dunolint
+  name: Dunolint
+  description: Linter and formatter for Dune files
+  language: system
+  entry: bash -c 'for n in $(seq 0 "$#"); do dunolint tools lint-file --in-place "${!n}"; done'
+  files: "^(.*/)?dune(-project)?$"

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,11 @@
+# Building these docs
+
+npm is needed to build the dunolint docs, which are built on
+[docusaurus](https://docusaurus.io/). To install the necessary
+prerequisites and launch a local development server, do:
+
+```shell
+# in the doc folder
+$ npm install
+$ npm run start
+```

--- a/doc/docs/guides/pre-commit.md
+++ b/doc/docs/guides/pre-commit.md
@@ -1,0 +1,11 @@
+# Using `dunolint` in pre-commit hooks
+
+Dunolint can be used to lint and format dune files automatically before commit, using a [pre-commit](https://pre-commit.com/) hook. This repo contains the configuration for such a hook. It doesn't sandbox the command, so you need to have the `dunolint` command available in your path.
+
+Then, add to the `.pre-commit-config.yaml` of your project:
+
+```yaml
+- repo: https://github.com/mbarbin/dunolint
+  hooks:
+    - id: dunolint
+```

--- a/doc/sidebars.ts
+++ b/doc/sidebars.ts
@@ -29,6 +29,7 @@ const sidebars: SidebarsConfig = {
       items: [
         { type: 'doc', id: 'guides/README', label: 'Introduction' },
         { type: 'doc', id: 'guides/reformatter', label: 'Using dunolint as an Emacs reformatter' },
+        { type: 'doc', id: 'guides/pre-commit', label: 'Using dunolint in pre-commit hooks' },
       ],
     },
   ],


### PR DESCRIPTION
Hi again, I was looking to add the `.pre-commit-hooks.yml` definition today when I made an annoying discovery. Seems like pre-commits wants to pass all staged files to the linter in one invocation. That is, if the files staged for commit are `foo/dune` and `bar/dune`, then it will attempt to call `dunolint tools lint-file --in-place foo/dune bar/dune`, which dunolint does not support. As discussed [here](https://github.com/pre-commit/pre-commit/issues/1728), there's no configuration around this, instead the pre-commot author proposes that the users do something like `bash -c 'for n in $(seq 0 "$#"); do mycommand "${!n}"; done'`... which is a bit sad.

Complication seems to come from the fact that the it'd only make sense to supply multiple files on the CLI when the `--in-place` flag is provided. Likewise, the `--filename` flag makes no sense if there are multiple files on the CLI. Perhaps the easiest thing to do is to split this into a separate tool, `dunolint tools lint-file-in-place` ?

---

Anyway, here's a `.pre-commit-hooks.yaml` based on the workaround described above.

## Documentation

I'd like to document this thing but unsure where to insert the docs. README.md? Or the [docs](https://mbarbin.github.io/dunolint/)?

Here's the docs I'd like to add, although the wording and flavor might change a bit depending on where we add it:


> Dunolint can be used to lint and format dune files automatically before commit, using a [pre-commit](https://pre-commit.com/) hook. This repo contains the configuration for such a hook. It doesn't sandbox the command, so you need to have the `dunolint` command available in your path.
> 
> Then, add to the `.pre-commit-config.yaml` of your project:
> 
> ```yaml
> - repo: https://github.com/mbarbin/dunolint
>   hooks:
>     - id: dunolint
> ```

## How to test:

1. Install pre-commit (on debian/ubuntu, `sudo apt install pre-commit` should work)
2. Ensure that dunolint is in `PATH`.
1. Go to a repo containing dune files and which does not already have a pre-commit hook.
3. Add the following configuration to `.pre-commit-config.yaml`.

```yaml
repos:
  - repo: https://github.com/arvidj/dunolint
    rev: 76017ac
    hooks:
      - id: dunolint
```
Note that: if this PR is merged, the `rev:` field will no longer be necessary and the repo will be mbarbin/dunolint instead.

5. Run `pre-commit install`. 

Then:
1. Modify some dune file `FILE` such that dunolint would reformat it.
2. Run `pre-commit run dunolint --verbose --files FILE`
Observe that `FILE` has been reformatted.

Or, run `pre-commit run dunolint --all-files` and all dune/dune-project files in the repo will be reformatted.

You can also try modifying a dune file such that `dunolint` would reformat it. Then try to commit the file in git. Pre-commit should run and stop the commit:
```
$ git commit dune -m 'Test'
Dunolint.................................................................Failed
- hook id: dunolint
- files were modified by this hook
```