### PR TITLE
Document usage as an Emacs reformatter

### DIFF
--- a/doc/docs/guides/reformatter.md
+++ b/doc/docs/guides/reformatter.md
@@ -1,0 +1,11 @@
+# Using `dunolint` as an Emacs reformatter
+
+**dunolint** can be used to automatically reformat dune files during editing with Emacs using the [reformatter](https://github.com/purcell/emacs-reformatter) package. Once the latter is installed, a dunolint reformatter can be configured as such:
+
+```elisp
+(reformatter-define dunolint-format
+  :program "dunolint"
+  :args (list "tools" "lint-file" "--filename" (buffer-file-name))
+  :lighter " DoF")
+```
+

--- a/doc/sidebars.ts
+++ b/doc/sidebars.ts
@@ -28,6 +28,7 @@ const sidebars: SidebarsConfig = {
       label: 'Guides',
       items: [
         { type: 'doc', id: 'guides/README', label: 'Introduction' },
+        { type: 'doc', id: 'guides/reformatter', label: 'Using dunolint as an Emacs reformatter' },
       ],
     },
   ],


### PR DESCRIPTION
This section feels a bit out of place in the README.md, but not sure where to put it. Open to suggestions :) 