### PR TITLE
Sync vendor git_pager with upstream

### DIFF
--- a/vendor/git_pager/dune
+++ b/vendor/git_pager/dune
@@ -4,5 +4,5 @@
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
  (libraries pp pplumbing.err pplumbing.pp-tty unix)
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess no_preprocessing))

--- a/vendor/git_pager/dune
+++ b/vendor/git_pager/dune
@@ -1,18 +1,8 @@
 (library
  (name dunolint_vendor_git_pager)
  (public_name dunolint.vendor_git_pager)
- (flags
-  :standard
-  -w
-  +a-4-40-41-42-44-45-48-66
-  -warn-error
-  +a
-  -open
-  Base
-  -open
-  Stdio)
- (libraries base pp pplumbing.err pplumbing.pp-tty stdio unix)
+ (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
+ (libraries pp pplumbing.err pplumbing.pp-tty unix)
  (lint
-  (pps ppx_js_style -allow-let-operators -check-doc-comments))
- (preprocess
-  (pps -unused-code-warnings=force ppx_sexp_conv)))
+  (pps ppx_js_style -check-doc-comments))
+ (preprocess no_preprocessing))

--- a/vendor/git_pager/git_pager.ml
+++ b/vendor/git_pager/git_pager.ml
@@ -1,169 +1,222 @@
 (*********************************************************************************)
-(*  Git_pager - Show diffs in the terminal with the user's configured git pager  *)
-(*  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>            *)
-(*                                                                               *)
-(*  This file is part of Git_pager.                                              *)
-(*                                                                               *)
-(*  Git_pager is free software; you can redistribute it and/or modify it         *)
-(*  under the terms of the GNU Lesser General Public License as published by     *)
-(*  the Free Software Foundation either version 3 of the License, or any later   *)
-(*  version, with the LGPL-3.0 Linking Exception.                                *)
-(*                                                                               *)
-(*  Git_pager is distributed in the hope that it will be useful, but WITHOUT     *)
-(*  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or        *)
-(*  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License  *)
-(*  and the file `NOTICE.md` at the root of this repository for more details.    *)
-(*                                                                               *)
-(*  You should have received a copy of the GNU Lesser General Public License     *)
-(*  and the LGPL-3.0 Linking Exception along with this library. If not, see      *)
-(*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.         *)
+(*  Git_pager - Run a Git pager to display diffs and other custom outputs        *)
+(*  SPDX-FileCopyrightText: 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>  *)
+(*  SPDX-License-Identifier: MIT                                                 *)
 (*********************************************************************************)
 
 module Unix = UnixLabels
 
 type t =
   { output_kind : [ `Tty | `Pager | `Other ]
-  ; color : [ `Auto | `Always | `Never ]
+  ; git_color_mode : [ `Auto | `Always | `Never ]
   ; write_end : Out_channel.t
   }
 
-let should_force_color { output_kind; color; write_end = _ } =
-  match output_kind, color with
-  | `Pager, `Auto ->
-    (* This is the only case in which Git on its own would make the wrong
-       decision if we did nothing to help. If we ran the command in a terminal,
-       Git would normally color it, but because we are sending its output to a
-       pipe, the [auto] strategy is confused and Git disables the colors. In all
-       other cases we return [false]. It doesn't mean we'll get no color, it
-       just means we let Git decide on its own. *)
-    true
-  | `Pager, (`Always | `Never) | (`Other | `Tty), (`Always | `Auto | `Never) -> false
-;;
-
+let output_kind t = t.output_kind
+let git_color_mode t = t.git_color_mode
 let write_end t = t.write_end
+
+let should_enable_color t =
+  match git_color_mode t with
+  | `Always -> true
+  | `Never -> false
+  | `Auto ->
+    (match output_kind t with
+     | `Tty -> true
+     | `Other -> false
+     | `Pager ->
+       (* That case is unreachable by design. *)
+       true
+       [@coverage off])
+;;
 
 module Process_status = struct
   type t = Unix.process_status =
     | WEXITED of int
     | WSIGNALED of int
     | WSTOPPED of int
-  [@@deriving sexp_of]
+
+  let to_string t =
+    match t with
+    | WEXITED i -> Printf.sprintf "Exited %d" i
+    | WSIGNALED i -> Printf.sprintf "Signaled %d" i [@coverage off]
+    | WSTOPPED i -> Printf.sprintf "Stopped %d" i [@coverage off]
+  ;;
 end
 
-let get_git_pager () =
-  match
-    (* We shortcut git entirely when [GIT_PAGER=cat] so we can run this code in
-       tests that do not have an actual git environment, such as in the dune
-       [.sandbox/.git]. *)
-    match Unix.getenv "GIT_PAGER" with
-    | exception Stdlib.Not_found -> None
-    | "cat" -> Some "cat"
-    | _ -> None
-  with
-  | Some value -> value
-  | None ->
-    let ((in_ch, _) as process) =
-      Unix.open_process_args "git" [| "git"; "var"; "GIT_PAGER" |]
-    in
-    let output = In_channel.input_all in_ch in
-    (match Unix.close_process process with
-     | WEXITED 0 -> output |> String.strip
+module String_tty = struct
+  type t = string
+
+  let to_string t = t
+end
+
+let git_pager_value =
+  lazy
+    (match
+       (* We shortcut git entirely when [GIT_PAGER=cat] so we can run this code in
+          tests that do not have an actual git environment, such as in the dune
+          [.sandbox/.git]. *)
+       match Unix.getenv "GIT_PAGER" with
+       | exception Stdlib.Not_found -> None
+       | "cat" -> Some "cat"
+       | _ -> None
+     with
+     | Some value -> value
+     | None ->
+       let ((in_ch, _) as process) =
+         Unix.open_process_args "git" [| "git"; "var"; "GIT_PAGER" |]
+       in
+       let output = In_channel.input_all in_ch in
+       (match Unix.close_process process with
+        | WEXITED 0 -> output |> String.trim
+        | (WEXITED _ | WSIGNALED _ | WSTOPPED _) as process_status ->
+          Err.raise
+            Pp.O.
+              [ Pp.text "Failed to get the value of "
+                ++ Pp_tty.kwd (module String_tty) "GIT_PAGER"
+                ++ Pp.text "."
+              ; Pp_tty.id (module Process_status) process_status
+              ]))
+;;
+
+let git_color_ui_value =
+  lazy
+    (let ((in_ch, _) as process) =
+       Unix.open_process_args "git" [| "git"; "config"; "--get"; "color.ui" |]
+     in
+     let output = In_channel.input_all in_ch in
+     match Unix.close_process process with
+     | WEXITED (0 | 1) ->
+       (match output |> String.trim with
+        | "" | "auto" -> `Auto
+        | "always" -> `Always
+        | "never" -> `Never
+        | other ->
+          Err.raise
+            Pp.O.
+              [ Pp.text "Unexpected "
+                ++ Pp_tty.kwd (module String_tty) "git color.ui"
+                ++ Pp.text " value "
+                ++ Pp_tty.id (module String_tty) other
+                ++ Pp.text "."
+              ])
      | (WEXITED _ | WSIGNALED _ | WSTOPPED _) as process_status ->
        Err.raise
          Pp.O.
            [ Pp.text "Failed to get the value of "
-             ++ Pp_tty.kwd (module String) "GIT_PAGER"
+             ++ Pp_tty.kwd (module String_tty) "color.ui"
              ++ Pp.text "."
-           ; Err.pp_of_sexp (Process_status.sexp_of_t process_status)
+           ; Pp_tty.id (module Process_status) process_status
            ])
 ;;
 
-let get_git_color () =
-  let ((in_ch, _) as process) =
-    Unix.open_process_args "git" [| "git"; "config"; "--get"; "color.ui" |]
-  in
-  let output = In_channel.input_all in_ch in
-  match Unix.close_process process with
-  | WEXITED (0 | 1) ->
-    (match output |> String.strip with
-     | "" | "auto" -> `Auto
-     | "always" -> `Always
-     | "never" -> `Never
-     | other ->
-       Err.raise
-         Pp.O.
-           [ Pp.text "Unexpected "
-             ++ Pp_tty.kwd (module String) "git color.ui"
-             ++ Pp.text " value "
-             ++ Pp_tty.id (module String) other
-             ++ Pp.text "."
-           ])
-  | (WEXITED _ | WSIGNALED _ | WSTOPPED _) as process_status ->
-    Err.raise
-      Pp.O.
-        [ Pp.text "Failed to get the value of "
-          ++ Pp_tty.kwd (module String) "color.ui"
-          ++ Pp.text "."
-        ; Err.pp_of_sexp (Process_status.sexp_of_t process_status)
-        ]
-;;
-
-let git_pager = lazy (get_git_pager ())
-let get_git_color = lazy (get_git_color ())
+let get_git_pager () = Lazy.force git_pager_value
+let get_git_color_ui () = Lazy.force git_color_ui_value
 
 let rec waitpid_non_intr pid =
   try Unix.waitpid ~mode:[] pid with
   | Unix.Unix_error (EINTR, _, _) -> waitpid_non_intr pid
 ;;
 
+let force_stdout_isatty_test = ref false
+
 let run ~f =
-  let git_pager = force git_pager in
-  let stdout_isatty = Unix.isatty Unix.stdout in
-  let pager_is_disabled = (not stdout_isatty) || String.equal git_pager "cat" in
+  let git_pager = get_git_pager () in
   let output_kind =
-    match pager_is_disabled, stdout_isatty with
-    | true, true -> `Tty
-    | true, false -> `Other
-    | false, true -> `Pager
-    | false, false -> assert false
+    if (Unix.isatty Unix.stdout [@coverage off]) || !force_stdout_isatty_test
+    then if String.equal git_pager "cat" then `Tty else `Pager
+    else `Other
+  in
+  let git_color_mode =
+    match Err.color_mode () with
+    | (`Always | `Never) as override -> override
+    | `Auto as auto ->
+      (match output_kind with
+       | `Tty | `Other -> auto
+       | `Pager ->
+         (match get_git_color_ui () with
+          | (`Always | `Never) as override -> override
+          | `Auto -> `Always))
   in
   match output_kind with
-  | `Tty | `Other -> f { output_kind; color = `Auto; write_end = stdout }
+  | `Tty | `Other -> f { output_kind; git_color_mode; write_end = Out_channel.stdout }
   | `Pager ->
-    let color = force get_git_color in
     let process_env =
       let env = Unix.environment () in
-      if Array.exists env ~f:(fun s -> String.is_prefix s ~prefix:"LESS=")
+      if Array.exists (fun s -> String.starts_with ~prefix:"LESS=" s) env
       then env
       else Array.append env [| "LESS=FRX" |]
     in
     let pager_in, pager_out = Unix.pipe ~cloexec:true () in
     let process =
+      let prog, args =
+        match String.split_on_char ' ' git_pager with
+        | [] -> assert false (* By specification of [String.split_on_char]. *)
+        | [ _ ] -> git_pager, [| git_pager |]
+        | prog :: _ as args -> prog, Array.of_list args
+      in
       Unix.create_process_env
-        ~prog:git_pager
-        ~args:[| git_pager |]
+        ~prog
+        ~args
         ~env:process_env
         ~stdin:pager_in
         ~stdout:Unix.stdout
         ~stderr:Unix.stderr
     in
     Unix.close pager_in;
-    let out_ch = Unix.out_channel_of_descr pager_out in
-    Exn.protect
-      ~f:(fun () ->
-        let res = f { output_kind; color; write_end = out_ch } in
-        Out_channel.flush out_ch;
-        res)
-      ~finally:(fun () ->
-        Out_channel.close out_ch;
-        match waitpid_non_intr process |> snd with
-        | WEXITED 0 -> ()
-        | (WEXITED _ | WSIGNALED _ | WSTOPPED _) as process_status ->
-          Err.raise
-            Pp.O.
-              [ Pp.text "Call to "
-                ++ Pp_tty.kwd (module String) "GIT_PAGER"
-                ++ Pp.text "failed."
-              ; Err.pp_of_sexp (Process_status.sexp_of_t process_status)
-              ])
+    let write_end = Unix.out_channel_of_descr pager_out in
+    let result =
+      match
+        let res = f { output_kind; git_color_mode; write_end } in
+        Out_channel.flush write_end;
+        res
+      with
+      | res -> Ok res
+      | exception e ->
+        let bt = Printexc.get_raw_backtrace () in
+        Error (bt, e)
+    in
+    (match
+       Out_channel.close write_end;
+       waitpid_non_intr process |> snd
+     with
+     | WEXITED 0 ->
+       (match result with
+        | Ok res -> res
+        | Error (bt, exn) -> Printexc.raise_with_backtrace exn bt)
+     | exception finally_exn ->
+       Err.raise
+         Pp.O.
+           [ Pp.text "Call to "
+             ++ Pp_tty.kwd (module String_tty) "GIT_PAGER"
+             ++ Pp.text " raised."
+           ; Pp.text "Writer Status: "
+             ++ (match result with
+               | Ok _ -> Pp.text "Ok"
+               | Error (_, exn) -> Pp.text "Raised " ++ Pp_tty.id (module Printexc) exn)
+             ++ Pp.text "."
+           ; Pp.text "Pager Exception: "
+             ++ Pp_tty.id (module Printexc) finally_exn
+             ++ Pp.text "."
+           ] [@coverage off]
+     | (WEXITED _ | WSIGNALED _ | WSTOPPED _) as process_status ->
+       (* This line is covered but off due to unvisitable out-edge point. *)
+       Err.raise
+         Pp.O.
+           [ Pp.text "Call to "
+             ++ Pp_tty.kwd (module String_tty) "GIT_PAGER"
+             ++ Pp.text " failed."
+           ; Pp.text "Writer Status: "
+             ++ (match result with
+               | Ok _ -> Pp.text "Ok"
+               | Error (_, exn) -> Pp.text "Raised " ++ Pp_tty.id (module Printexc) exn)
+             ++ Pp.text "."
+           ; Pp.text "Pager Exit Status: "
+             ++ Pp_tty.id (module Process_status) process_status
+             ++ Pp.text "."
+           ] [@coverage off])
 ;;
+
+module Private = struct
+  let force_stdout_isatty_test = force_stdout_isatty_test
+end

--- a/vendor/git_pager/git_pager.mli
+++ b/vendor/git_pager/git_pager.mli
@@ -1,35 +1,85 @@
 (*_********************************************************************************)
-(*_  Git_pager - Show diffs in the terminal with the user's configured git pager  *)
-(*_  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>            *)
-(*_                                                                               *)
-(*_  This file is part of Git_pager.                                              *)
-(*_                                                                               *)
-(*_  Git_pager is free software; you can redistribute it and/or modify it         *)
-(*_  under the terms of the GNU Lesser General Public License as published by     *)
-(*_  the Free Software Foundation either version 3 of the License, or any later   *)
-(*_  version, with the LGPL-3.0 Linking Exception.                                *)
-(*_                                                                               *)
-(*_  Git_pager is distributed in the hope that it will be useful, but WITHOUT     *)
-(*_  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or        *)
-(*_  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License  *)
-(*_  and the file `NOTICE.md` at the root of this repository for more details.    *)
-(*_                                                                               *)
-(*_  You should have received a copy of the GNU Lesser General Public License     *)
-(*_  and the LGPL-3.0 Linking Exception along with this library. If not, see      *)
-(*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.         *)
+(*_  Git_pager - Run a Git pager to display diffs and other custom outputs        *)
+(*_  SPDX-FileCopyrightText: 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>  *)
+(*_  SPDX-License-Identifier: MIT                                                 *)
 (*_********************************************************************************)
+
+(** Run a Git pager to display diffs and other custom outputs.
+
+    The pager used is the one configured by Git. If [GIT_PAGER=cat], the pager
+    is effectively disabled, and output is sent directly to stdout.
+
+    This module is particularly useful for tools that integrate with Git and
+    need to display output exceeding one screen, while respecting user color
+    preferences and Git's configuration. *)
 
 type t
 
-(** Git commands should force colors in the case where the color configuration
-    is set to "auto" and we are sending the diff to a pager. This would be
-    the behavior of [git diff] itself, but since we are running the pager
-    ourselves here, without taking specific measures, [git diff] would
-    disable colors. When [should_force_color=true], the expectation is that
-    the git commands should be supplied [--color=always]. *)
-val should_force_color : t -> bool
+(** Runs a Git pager and waits for its termination.
 
-(** This is where lines to be sent to the pager should be written to. *)
+    Example:
+    {[
+      Git_pager.run ~f:(fun pager ->
+        let write_end = Git_pager.write_end pager in
+        Printf.fprintf write_end "Hello, pager!\n")
+    ]} *)
+val run : f:(t -> 'a) -> 'a
+
+(** This is where lines to be sent to the pager should be written. You may flush
+    the write end of the pager as needed, however note that [run] already ends
+    with a call to [Out_channel.flush]. *)
 val write_end : t -> Out_channel.t
 
-val run : f:(t -> 'a) -> 'a
+(** {1 Color Handling} *)
+
+(** Returns the appropriate color mode to use for Git commands whose outputs are
+    sent to the pager.
+
+    The color mode is decided based on:
+    1. The command-line flag [--color=(auto|always|never)] (via [Err.color_mode]).
+    2. Git's configuration for [color.ui].
+    3. The output context (e.g., terminal, pager, or redirection).
+
+    If both the command-line flag and [color.ui] are set to [auto], and the
+    output is being sent to a pager, this function returns [`Always] to ensure
+    colored output.
+
+    Example:
+    {[
+      let git_diff_flags git_pager =
+        match Git_pager.git_color_mode git_pager with
+        | `Auto -> []
+        | `Always -> [ "--color=always" ]
+        | `Never -> [ "--color=never" ]
+      ;;
+    ]} *)
+val git_color_mode : t -> [ `Auto | `Always | `Never ]
+
+(** Based on the current color mode and output kind, says whether outputs sent
+    to the pager should contain colors. It is useful for configuring custom
+    outputs rendering or other non-Git commands. *)
+val should_enable_color : t -> bool
+
+(** Returns the kind of [t]'s output.
+
+    - [`Tty]: Output is sent directly to a terminal (pager is disabled).
+    - [`Pager]: Output is sent to a pager, as configured by Git.
+    - [`Other]: Output is redirected (e.g., piped to another command or written to a file).
+
+    See also {!should_enable_color}. *)
+val output_kind : t -> [ `Tty | `Pager | `Other ]
+
+(** {1 Private}
+
+    This module is exported to be used by libraries with strong ties to
+    [git-pager] and by tests. Its signature may change in breaking ways at any
+    time without prior notice, and outside of the guidelines set by semver.
+
+    Do not use. *)
+
+module Private : sig
+  (** So that we can exercise the pager logic in a test where stdout is never
+      a tty, we export this reference to force the module behavior as if stdout
+      was a tty. *)
+  val force_stdout_isatty_test : bool ref
+end


### PR DESCRIPTION
I had plans for Git_pager to become a standalone package, as I wish to re-use it in other projects.

I've prepared an initial publication here : https://github.com/mbarbin/git-pager

It is not published to opam and doesn't have a release yet. For now I wish to continue to vendor it, while the code stabilizes, and awaiting for the package to be published to opam (TBD).

Still, I thought it would be useful to run the same code, so I'm importing the changes here in the vendor directory.