### PR TITLE
Implicit transitive deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
       #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
       #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 
+      # Setting `(implicit_transitive_deps VALUE)` conditionally based on the compiler version.
+      - name: Edit dune-project
+        run: opam exec -- ocaml .github/workflows/edit_dune_project_dot_ml "${{ matrix.ocaml-compiler }}"
+
       - name: Install dependencies
         run: opam install . --deps-only --with-doc --with-test --with-dev-setup
 
@@ -58,6 +62,11 @@ jobs:
 
       - name: Lint dunolint
         run: ./dunolint.sh
+
+      # Before checking for uncommitted changes we need to restore changes
+      # potentially made to the dune-project file.
+      - name: Restore dune-project
+        run: git restore dune-project
 
       - name: Check for uncommitted changes
         run: git diff --exit-code

--- a/.github/workflows/edit_dune_project_dot_ml
+++ b/.github/workflows/edit_dune_project_dot_ml
@@ -1,0 +1,73 @@
+(* Usage: ocaml .github/workflows/edit_dune_project_dot_ml <ocaml-version> *)
+
+let starts_with s prefix =
+  let len_s = String.length s in
+  let len_p = String.length prefix in
+  len_s >= len_p && String.sub s 0 len_p = prefix
+;;
+
+let is_implicit_transitive_deps_line line =
+  let prefix = "(implicit_transitive_deps" in
+  starts_with (String.trim line) prefix
+;;
+
+let () =
+  let usage () =
+    Printf.eprintf
+      "Error: OCaml version argument required. Usage: %s <ocaml-version>\n"
+      Sys.argv.(0);
+    exit 1
+  in
+  if Array.length Sys.argv < 2 then usage ();
+  let version = Sys.argv.(1) in
+  let dune_project = "dune-project" in
+  let file_lines =
+    try
+      let ic = open_in dune_project in
+      let rec loop acc =
+        match input_line ic with
+        | line -> loop (line :: acc)
+        | exception End_of_file -> List.rev acc
+      in
+      let lines = loop [] in
+      close_in ic;
+      lines
+    with
+    | Sys_error _ ->
+      Printf.eprintf "File not found: %s\n" dune_project;
+      exit 1
+  in
+  let major, minor =
+    try
+      match String.split_on_char '.' version with
+      | major :: minor :: _ -> int_of_string major, int_of_string minor
+      | _ -> failwith "Invalid version format"
+    with
+    | _ ->
+      Printf.eprintf "Invalid OCaml version: %s\n" version;
+      exit 1
+  in
+  let should_be_false = major > 5 || (major = 5 && minor >= 2) in
+  let changed = ref false in
+  let new_lines =
+    List.map
+      (fun line ->
+         if is_implicit_transitive_deps_line line
+         then (
+           changed := true;
+           Printf.sprintf
+             "(implicit_transitive_deps %s)"
+             (if should_be_false then "false" else "true"))
+         else line)
+      file_lines
+  in
+  if !changed
+  then (
+    let oc = open_out dune_project in
+    List.iter
+      (fun l ->
+         output_string oc l;
+         output_char oc '\n')
+      new_lines;
+    close_out oc)
+;;

--- a/.github/workflows/more-ci.yml
+++ b/.github/workflows/more-ci.yml
@@ -54,6 +54,10 @@ jobs:
       #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
       #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 
+      # Setting `(implicit_transitive_deps VALUE)` conditionally based on the compiler version.
+      - name: Edit dune-project
+        run: opam exec -- ocaml .github/workflows/edit_dune_project_dot_ml "${{ matrix.ocaml-compiler }}"
+
       # We build and run tests for a subset of packages. More tests are run in
       # the development workflow and as part of the main CI job. These are the
       # tests that are checked for every combination of os and ocaml-compiler.

--- a/.github/workflows/ocaml-4-ci.yml
+++ b/.github/workflows/ocaml-4-ci.yml
@@ -38,13 +38,9 @@ jobs:
       #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
       #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 
-      # This construct is not well supported by older OCaml versions. Given that
-      # we already check the build with this option in the main CI job, we
-      # disable it here unconditionally for simplicity.
+      # Setting `(implicit_transitive_deps VALUE)` conditionally based on the compiler version.
       - name: Edit dune-project
-        shell: pwsh
-        run: |
-          (Get-Content dune-project) -notmatch '\(implicit_transitive_deps false\)' | Set-Content dune-project
+        run: opam exec -- ocaml .github/workflows/edit_dune_project_dot_ml "${{ matrix.ocaml-compiler }}"
 
       # We build and run tests for a subset of packages. More tests are run in
       # the development workflow and as part of the main CI job. These are the

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,17 @@
 
 (using mdx 0.4)
 
-(implicit_transitive_deps false)
+;; The value for the [implicit_transtive_deps] option is set during the CI
+;; depending on the OCaml compiler version.
+;;
+;; This will be set to [false] iif [ocaml-version >= 5.2].
+;;
+;; For packaging purposes with older ocaml, it is simpler atm if the option is
+;; set to [true] in the main branch.
+;;
+;; See: [.github/workflows/edit_dune_project_dot_ml].
+
+(implicit_transitive_deps true)
 
 (package
  (name dunolint-lib)


### PR DESCRIPTION
Until we switch to dune 3.20 we'll manually set `(implicit_transitive_deps _)` depending on the compiler version.

This can be simplified with `(implicit_transitive_deps false-if-hidden-includes-supported)` when it lands with `dune 3.20`.