### PR TITLE
Fix cram tests

### DIFF
--- a/doc/docs/explanation/linting-equilibrium/comments-in-libraries.md
+++ b/doc/docs/explanation/linting-equilibrium/comments-in-libraries.md
@@ -6,7 +6,8 @@ The `libraries` dependencies listed in `library` stanzas are sorted alphabetical
 $ cat > dune0 <<EOF\
 > (library\
 >  (name my_lib)\
->  (libraries foo bar baz))
+>  (libraries foo bar baz))\
+> EOF
 ```
 
 is linted as follows:

--- a/test/cram/interactive.t
+++ b/test/cram/interactive.t
@@ -63,7 +63,7 @@ We disable the pager for the test.
 
 We can quit at any time during the interactive loop.
 
-  $ echo 'q' | dunolint lint --config=.dunolint --interactive
+  $ printf 'q\n' | dunolint lint --config=.dunolint --interactive
   Would edit file "dune-project":
   -1,1 +1,1
   -|(name main)
@@ -73,7 +73,7 @@ We can quit at any time during the interactive loop.
 
 We can choose to refuse some diff, and accept others.
 
-  $ echo 'n\ny\n' | dunolint lint --config=.dunolint --interactive
+  $ printf 'n\ny\n' | dunolint lint --config=.dunolint --interactive
   Would edit file "dune-project":
   -1,1 +1,1
   -|(name main)

--- a/test/cram/lint-file.t
+++ b/test/cram/lint-file.t
@@ -255,9 +255,10 @@ contents is saved in the input file and not at the overridden path.
    (name mylib)
    (libraries a b c))
 
-  $ ls -l path/to/dune
-  ls: cannot access 'path/to/dune': No such file or directory
-  [2]
+This should not have created a file with the given filename.
+
+  $ test -e path/to/dune
+  [1]
 
 The command is idempotent.
 

--- a/test/cram/lint-file.t
+++ b/test/cram/lint-file.t
@@ -3,7 +3,7 @@ We test it here while calling it from the shell.
 
 By default the command reads from `stdin`.
 
-  $ echo '(lang dune 3.17)' | dunolint tools lint-file
+  $ printf '(lang dune 3.17)\n' | dunolint tools lint-file
   Error: Cannot infer the file kind from the filename "stdin".
   Hint: You may override the filename with the flag [--filename].
   [123]
@@ -11,17 +11,17 @@ By default the command reads from `stdin`.
 However, when using the command that way, the linted file kind won't be
 inferred. The filename must end with a basename that indicates a supported mode.
 
-  $ echo '(lang dune 3.17)' | dunolint tools lint-file --filename=dune-project
+  $ printf '(lang dune 3.17)\n' | dunolint tools lint-file --filename=dune-project
   (lang dune 3.17)
 
 By default, the contents is auto-formatted.
 
-  $ echo '(lang\n dune\n 3.17)' | dunolint tools lint-file --filename=dune-project
+  $ printf '(lang\n dune\n 3.17)\n' | dunolint tools lint-file --filename=dune-project
   (lang dune 3.17)
 
 The formatting may however be disabled.
 
-  $ echo '(lang\n dune\n 3.17)' \
+  $ printf '(lang\n dune\n 3.17)\n' \
   > | dunolint tools lint-file --filename=dune-project \
   >   --format-file=false
   (lang
@@ -100,7 +100,7 @@ When the command fails to parse the file, it complains and exits with a non-zero
 code. This should be handled by the logic responsible for the editor
 integration.
 
-  $ echo "(invalid sexp" | dunolint tools lint-file --filename=dune
+  $ printf "(invalid sexp\n" | dunolint tools lint-file --filename=dune
   File "dune", line 2, characters 0-0:
   Error: unclosed parentheses at end of input
   [123]
@@ -109,7 +109,7 @@ Next we are going to test the command with config.
 
 The command may be passed a config file.
 
-  $ echo '((rules ()))' > .dunolint
+  $ printf '((rules ()))\n' > .dunolint
 
   $ dunolint tools lint dune --config=.dunolint
   (library

--- a/test/cram/lint.t
+++ b/test/cram/lint.t
@@ -37,14 +37,14 @@ its own. See below how the name of the project is not linted:
 
 If the config is supplied, but it is invalid, dunolint will complain.
 
-  $ echo '(blah)' > .dunolint
+  $ printf '(blah)\n' > .dunolint
 
   $ dunolint lint --yes --config .dunolint 2> /dev/null
   [125]
 
 If there are no rules, the linting will succeed but does nothing in this case.
 
-  $ echo '((rules ()))' > .dunolint
+  $ printf '((rules ()))\n' > .dunolint
 
   $ dunolint lint --yes --config .dunolint
 


### PR DESCRIPTION
Attend some failure noticed in `ocaml-ci`:

- Add missing EOF marker.
- Replace `echo` by hopefully more portable `printf` in particular for escaped sequences such as interactive input.
- Stop using `ls` since it produces slightly different outputs on different os (e.g. ubuntu-latest vs macos-latest).