### PR TITLE
Add volgo-vcs dependencies

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -109,7 +109,15 @@
   (sexps-rewriter
    (>= 0.0.3))
   (stdio
-   (>= v0.17))))
+   (>= v0.17))
+  (volgo
+   (>= 0.0.21))
+  (volgo-base
+   (>= 0.0.21))
+  (volgo-git-unix
+   (>= 0.0.21))
+  (volgo-hg-unix
+   (>= 0.0.21))))
 
 (package
  (name dunolint-tests)
@@ -177,6 +185,16 @@
    (>= 0.0.3))
   (stdio
    (>= v0.17))
+  (volgo
+   (>= 0.0.21))
+  (volgo-base
+   (>= 0.0.21))
+  (volgo-git-unix
+   (>= 0.0.21))
+  (volgo-hg-unix
+   (>= 0.0.21))
+  (volgo-vcs
+   (>= 0.0.21))
   (sherlodoc
    (and
     :with-doc
@@ -264,6 +282,16 @@
    (>= 0.0.3))
   (stdio
    (>= v0.17))
+  (volgo
+   (>= 0.0.21))
+  (volgo-base
+   (>= 0.0.21))
+  (volgo-git-unix
+   (>= 0.0.21))
+  (volgo-hg-unix
+   (>= 0.0.21))
+  (volgo-vcs
+   (>= 0.0.21))
   (odoc
    (and
     :with-doc

--- a/dunolint-dev.opam
+++ b/dunolint-dev.opam
@@ -46,6 +46,11 @@ depends: [
   "sexplib0" {>= "v0.17"}
   "sexps-rewriter" {>= "0.0.3"}
   "stdio" {>= "v0.17"}
+  "volgo" {>= "0.0.21"}
+  "volgo-base" {>= "0.0.21"}
+  "volgo-git-unix" {>= "0.0.21"}
+  "volgo-hg-unix" {>= "0.0.21"}
+  "volgo-vcs" {>= "0.0.21"}
   "odoc" {with-doc & >= "2.4.4"}
   "sherlodoc" {with-doc & >= "0.2"}
 ]

--- a/dunolint-tests.opam
+++ b/dunolint-tests.opam
@@ -38,6 +38,11 @@ depends: [
   "sexplib0" {>= "v0.17"}
   "sexps-rewriter" {>= "0.0.3"}
   "stdio" {>= "v0.17"}
+  "volgo" {>= "0.0.21"}
+  "volgo-base" {>= "0.0.21"}
+  "volgo-git-unix" {>= "0.0.21"}
+  "volgo-hg-unix" {>= "0.0.21"}
+  "volgo-vcs" {>= "0.0.21"}
   "sherlodoc" {with-doc & >= "0.2"}
   "odoc" {with-doc}
 ]

--- a/dunolint.opam
+++ b/dunolint.opam
@@ -36,6 +36,10 @@ depends: [
   "sexplib0" {>= "v0.17"}
   "sexps-rewriter" {>= "0.0.3"}
   "stdio" {>= "v0.17"}
+  "volgo" {>= "0.0.21"}
+  "volgo-base" {>= "0.0.21"}
+  "volgo-git-unix" {>= "0.0.21"}
+  "volgo-hg-unix" {>= "0.0.21"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
This is to prepare the introduction of new functionality that will make use of the underlying vcs repository containing the build files to lint.