### PR TITLE
Change dune lang sexp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,18 @@
 ## 0.0.2025XXXX (unreleased)
 
+### Added
+
+- New lib `dunolint-lib-base` to extend `dunolint-lib` for base users (#99, @mbarbin).
+
 ### Changed
 
+- Change dune-lang sexps to be atoms (e.g. "3.19") instead of tuples (#101, @mbarbin).
+- Remove base and ppx dependencies from `dunolint-lib` (#99, @mbarbin).
 - Always use versioned sexp for config (#98, @mbarbin).
 
 ### Fixed
 
+- Improve location and messages for sexp loading errors (#100, @mbarbin).
 - Config loading errors are no longer internal errors and now reported with locations when able (#97, @mbarbin).
 
 ## 0.0.20250907 (2025-09-07)

--- a/dunolint-config/dunolint.sexp
+++ b/dunolint-config/dunolint.sexp
@@ -12,7 +12,7 @@
       skip_subtree))))
   (rules
    ((enforce
-     (dune_project (dune_lang_version (greater_than_or_equal_to (3 17)))))
+     (dune_project (dune_lang_version (greater_than_or_equal_to 3.17))))
     (cond
      (((path (glob dunolint-config/**/*))
        (enforce (dune (library (public_name (is_prefix dunolint-tests.))))))

--- a/lib/dune_project_linter/test/test__dune_lang_version.ml
+++ b/lib/dune_project_linter/test/test__dune_lang_version.ml
@@ -63,7 +63,7 @@ let%expect_test "read/write" =
 let%expect_test "sexp_of" =
   let _, t = parse {| (lang dune 3.20) |} in
   print_s [%sexp (t : Dune_project_linter.Dune_lang_version.t)];
-  [%expect {| ((dune_lang_version (3 20))) |}];
+  [%expect {| ((dune_lang_version 3.20)) |}];
   ()
 ;;
 
@@ -85,7 +85,7 @@ let%expect_test "rewrite" =
       [%sexp
         (Dune_project_linter.Dune_lang_version.dune_lang_version t
          : Dune_project.Dune_lang_version.t)];
-    [%expect {| (3 20) |}];
+    [%expect {| 3.20 |}];
     Dune_project_linter.Dune_lang_version.set_dune_lang_version
       t
       ~dune_lang_version:(Dune_project.Dune_lang_version.create (4, 10));
@@ -93,7 +93,7 @@ let%expect_test "rewrite" =
       [%sexp
         (Dune_project_linter.Dune_lang_version.dune_lang_version t
          : Dune_project.Dune_lang_version.t)];
-    [%expect {| (4 10) |}];
+    [%expect {| 4.10 |}];
     ());
   [%expect {| (lang dune 4.10) |}];
   ()

--- a/lib/dune_project_linter/test/test__dune_project_linter.ml
+++ b/lib/dune_project_linter/test/test__dune_project_linter.ml
@@ -96,7 +96,7 @@ let%expect_test "lint" =
         [%sexp
           (Dune_project_linter.Dune_lang_version.dune_lang_version s
            : Dune_project.Dune_lang_version.t)];
-      [%expect {| (3 17) |}];
+      [%expect {| 3.17 |}];
       Dune_project_linter.Dune_lang_version.set_dune_lang_version
         s
         ~dune_lang_version:(Dune_project.Dune_lang_version.create (3, 20));

--- a/lib/dunolint/src/import.ml
+++ b/lib/dunolint/src/import.ml
@@ -30,6 +30,12 @@ module Char = struct
   ;;
 end
 
+module Int = struct
+  include Int
+
+  let of_string_opt = int_of_string_opt
+end
+
 module List = struct
   include ListLabels
 

--- a/lib/dunolint/src/import.mli
+++ b/lib/dunolint/src/import.mli
@@ -27,6 +27,12 @@ module Char : sig
   val is_alphanum : char -> bool
 end
 
+module Int : sig
+  include module type of Int
+
+  val of_string_opt : string -> int option
+end
+
 module List : sig
   include module type of ListLabels
 


### PR DESCRIPTION
Change sexp representation of the dune lang in config to be an atom. This changes the sexp e.g. from '(3 19)' to '3.19'.

- This is more consistent with the representation in dune itself.
- The parsing of the list sexp is kept in reading for compatibility.