### PR TITLE
Fix workspace root in dune test envs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Fix workspace root detection in dune test envs (#120, @mbarbin).
 - Fix parsing errors of dune version in dune-project (#112, @mbarbin).
 
 ## 0.0.20250910-1 (2025-09-10)

--- a/lib/dunolint_cli/src/cmd__tools__find_workspace_root.ml
+++ b/lib/dunolint_cli/src/cmd__tools__find_workspace_root.ml
@@ -28,7 +28,8 @@ let main =
        directories. Dune requires at least one of these two files to operate.\n\n\
        See also $(i,https://dune.readthedocs.io/en/stable/usage.html#finding-the-root).")
     (let open Command.Std in
-     let+ root = Common_helpers.root in
+     let+ () = Log_cli.set_config ()
+     and+ root = Common_helpers.root in
      let workspace_root =
        Workspace_root.find_exn ~default_is_cwd:false ~specified_by_user:root
      in

--- a/test/cram/workspace-root.t
+++ b/test/cram/workspace-root.t
@@ -16,6 +16,13 @@ Exercise and monitor cases of finding the root of the current dune workspace.
 
   $ cd $ROOT
 
+We should also have code in place that ensure that during the dune tests
+environment, we are not using an actual enclosing repo dir as workspace root,
+even if that repo contains a `dune-workspace` root file.
+
+  $ dunolint tools find-workspace-root 2>&1 | head -n 1
+  Error: I cannot find the root of the current dune workspace/project.
+
   $ mkdir workspace-foo
 
   $ cd workspace-foo


### PR DESCRIPTION
This avoids actual enclosing repo dirs to be used as workspace root in dune tests.

- Put a pragmatic workaround in place for now, possibly improve as future work.