### PR TITLE
Always include default skip paths in configs

### DIFF
--- a/doc/docs/reference/default-rules.md
+++ b/doc/docs/reference/default-rules.md
@@ -38,6 +38,32 @@ We've focused on fields that have been most impactful in our experience, but we 
 
 Comments are preserved and moved along with their associated items. See [Comments in Libraries](../explanation/linting-equilibrium/comments-in-libraries.md) for detailed behavior.
 
+## Default Skipped Paths
+
+Dunolint automatically ignores certain directories that typically contain build artifacts, version control metadata, or third-party dependencies. These paths are skipped by default to avoid unnecessary linting and improve performance.
+
+### Skipped Directories
+
+The following directories are ignored by default (anywhere in your project tree, including nested locations):
+
+- `.git/` - Git version control metadata
+- `.hg/` - Mercurial version control metadata
+- `_build/` - Dune build artifacts
+- `_opam/` - Local OPAM switch
+- `_coverage/` - Code coverage reports
+- `node_modules/` - NPM dependencies
+- `doc/build/` - Documentation build artifacts
+- `.docusaurus/` - Docusaurus build artifacts
+- `*.t/` - Cram test directories
+
+These paths are skipped regardless of whether you have a custom configuration file. You can add your own skip paths using the `(skip_paths ...)` construct in your configuration file (see [Config Language Reference](config/README.md)).
+
+### Future Enhancements
+
+This default list is a baseline to get started. A more robust approach might involve integrating with version control ignore patterns (like `.gitignore` or `.hgignore`), though this presents challenges such as detecting which VCS is in use (if any).
+
+If you have ideas about how dunolint should handle default skip paths, or if you encounter directories that should be added to (or removed from) this default list, please share your feedback in the [discussions](https://github.com/mbarbin/dunolint/discussions) or [issues](https://github.com/mbarbin/dunolint/issues). Your input helps shape the tool's development!
+
 ## No Additional Rules by Default
 
 Apart from canonical ordering, dunolint does not enforce any other rules by default. To add more linting rules, you need to create a `dunolint` configuration file.

--- a/lib/dunolint_cli/src/cmd__lint.ml
+++ b/lib/dunolint_cli/src/cmd__lint.ml
@@ -61,7 +61,15 @@ let main =
      in
      Workspace_root.chdir workspace_root ~level:Warning;
      let root_configs =
-       [ Common_helpers.load_config_opt_exn ~config ~append_extra_rules:enforce ]
+       List.concat
+         [ [ Common_helpers.default_skip_paths_config () ]
+         ; (match Common_helpers.load_config_opt ~config with
+            | Some config -> [ config ]
+            | None -> [])
+         ; (match Common_helpers.enforce_rules_config ~rules:enforce with
+            | Some config -> [ config ]
+            | None -> [])
+         ]
      in
      Dunolint_engine.run ~root_configs ~running_mode
      @@ fun dunolint_engine ->

--- a/lib/dunolint_cli/src/cmd__tools__lint_file.ml
+++ b/lib/dunolint_cli/src/cmd__tools__lint_file.ml
@@ -208,7 +208,12 @@ let main =
      in
      Workspace_root.chdir workspace_root ~level:Debug;
      let root_configs =
-       [ Common_helpers.load_config_opt_exn ~config ~append_extra_rules:[] ]
+       List.concat
+         [ [ Common_helpers.default_skip_paths_config () ]
+         ; (match Common_helpers.load_config_opt ~config with
+            | Some config -> [ config ]
+            | None -> [])
+         ]
      in
      let context =
        List.fold

--- a/lib/dunolint_cli/src/common_helpers.mli
+++ b/lib/dunolint_cli/src/common_helpers.mli
@@ -30,12 +30,16 @@ val below : doc:string -> Fpath.t option Command.Arg.t
 (** A list of defaults directories to skip. *)
 val skip_subtrees : globs:string list -> Dunolint.Glob.t list
 
-(** A helper to load a config file, either supplied or inferred from the context
-    and add some optional rules. *)
-val load_config_opt_exn
-  :  config:string option
-  -> append_extra_rules:Dunolint.Config.Rule.t list
-  -> Dunolint.Config.t
+(** Create a default config with only skip_paths for common directories. *)
+val default_skip_paths_config : unit -> Dunolint.Config.t
+
+(** Create a config containing only the given enforce rules, or None if the list
+    is empty. *)
+val enforce_rules_config : rules:Dunolint.Config.Rule.t list -> Dunolint.Config.t option
+
+(** Load a config file from the given path, or try to load from the default
+    "dunolint" file if no path is provided. Returns None if no config is found. *)
+val load_config_opt : config:string option -> Dunolint.Config.t option
 
 (** Override the workspace root - same as with dune. *)
 val root : Absolute_path.t option Command.Arg.t

--- a/test/cram/lint-file.t
+++ b/test/cram/lint-file.t
@@ -246,17 +246,16 @@ If the file is at a path configured to be in a skipped directory, the command
 won't apply linting rules to it.
 
   $ cat dune | dunolint tools lint-file --filename=.git/dune --config=empty-config
-  (library
-   (name mylib)
-   (libraries a b c))
+  (library (name mylib)
+   (libraries b c a))
 
-It is ignored by the config [dunolint].
+The `.git/` directory is skipped by default, regardless of the config used.
 
   $ cat dune | dunolint tools lint-file --filename=.git/dune
   (library (name mylib)
    (libraries b c a))
 
-But if the file is not ignored, we see that it is linted.
+But if the file is not in a default skipped path, we see that it is linted.
 
   $ cat dune | dunolint tools lint-file --filename=linted/dune
   (library


### PR DESCRIPTION
Default skip paths (like .git/, _build/, etc.) are now always included in root_configs, regardless of whether a user provides a custom config.

- Added .hg/ to default skip paths
- Updated documentation