### PR TITLE
Located path refactor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "alphanum",
         "Blang",
+        "chdir",
         "Cmdlang",
         "conv",
         "dedup",

--- a/lib/dune_linter/src/dune_linter.ml
+++ b/lib/dune_linter/src/dune_linter.ml
@@ -68,17 +68,17 @@ module Linter = struct
         ~original_sexp
         ~sexps_rewriter
     =
-    let eval (t : m) ~predicate =
+    let eval (t : m) ~path ~predicate =
       match (predicate : Dunolint.Predicate.t) with
       | `path condition -> Dunolinter.eval_path ~path ~condition
       | `dune_project _ -> Dunolint.Trilang.Undefined
       | `dune condition ->
         Dunolint.Trilang.eval condition ~f:(fun predicate -> M.eval t ~predicate)
     in
-    let enforce =
+    let enforce (m : m) ~path ~condition =
       Dunolinter.Linter.enforce
         (module Dunolint.Predicate)
-        ~eval
+        ~eval:(fun t ~predicate -> eval t ~path ~predicate)
         ~enforce:(fun t predicate ->
           match predicate with
           | Not _ -> Eval
@@ -86,9 +86,11 @@ module Linter = struct
           | T (`dune condition) ->
             M.enforce t ~condition;
             Ok)
+        m
+        ~condition
     in
-    let eval predicate = eval inner_stanza ~predicate in
-    let enforce condition = enforce inner_stanza ~condition in
+    let eval ~path ~predicate = eval inner_stanza ~path ~predicate in
+    let enforce ~path ~condition = enforce inner_stanza ~path ~condition in
     Dunolinter.Private.Stanza.create
       { stanza; path; original_sexp; sexps_rewriter; linter = T { eval; enforce } }
   ;;

--- a/lib/dunolint_cli/src/cmd__tools__lint_file.ml
+++ b/lib/dunolint_cli/src/cmd__tools__lint_file.ml
@@ -182,12 +182,17 @@ let main =
          |> Relative_path.to_string)
      in
      Workspace_root.chdir workspace_root ~level:Debug;
+     let path =
+       match Option.first_some filename file with
+       | Some file -> file
+       | None -> Relative_path.v "stdin"
+     in
      let root_configs =
        List.concat
          [ [ Common_helpers.default_skip_paths_config () ]
          ; (match Common_helpers.load_config_opt ~config with
-            | Some config -> [ config ]
-            | None -> [])
+            | None -> []
+            | Some config -> [ config ])
          ]
      in
      let context =
@@ -195,11 +200,6 @@ let main =
          root_configs
          ~init:Dunolint_engine.Context.empty
          ~f:(fun context config -> Dunolint_engine.Context.add_config context ~config)
-     in
-     let path =
-       match Option.first_some filename file with
-       | Some file -> file
-       | None -> Relative_path.v "stdin"
      in
      let linter = select_linter ~path:(path :> Fpath.t) in
      let original_contents =

--- a/lib/dunolint_cli/src/cmd__tools__lint_file.ml
+++ b/lib/dunolint_cli/src/cmd__tools__lint_file.ml
@@ -67,7 +67,7 @@ let lint_file
     let (_ : [ `continue | `skip_subtree ]) =
       With_return.with_return (fun return ->
         File_linter.visit linter ~f:(fun stanza ->
-          Linter.lint_stanza ~context ~stanza ~return);
+          Linter.lint_stanza ~path ~context ~stanza ~return);
         `continue)
     in
     let new_contents = File_linter.contents linter in

--- a/lib/dunolint_cli/src/cmd__tools__lint_file.ml
+++ b/lib/dunolint_cli/src/cmd__tools__lint_file.ml
@@ -54,31 +54,6 @@ module Save_in_place = struct
   ;;
 end
 
-let skip_file ~context ~(path : Relative_path.t) =
-  let paths_to_check_for_skip_predicates =
-    Path_in_workspace.paths_to_check_for_skip_predicates ~path
-  in
-  List.exists (Dunolint_engine.Context.configs context) ~f:(fun config ->
-    match Dunolint.Config.Private.view config with
-    | `v0 v0 ->
-      (match Dunolint.Config.V0.skip_subtree v0 with
-       | None -> false
-       | Some condition ->
-         List.exists paths_to_check_for_skip_predicates ~f:(fun path ->
-           match
-             Dunolint.Rule.eval condition ~f:(fun (`path condition) ->
-               Dunolinter.eval_path ~path ~condition)
-           with
-           | `enforce _ -> .
-           | `return -> false
-           | `skip_subtree -> true))
-    | `v1 v1 ->
-      let skip_paths = Dunolint.Config.V1.skip_paths v1 |> List.concat in
-      List.exists paths_to_check_for_skip_predicates ~f:(fun path ->
-        let path = Relative_path.to_string path in
-        List.exists skip_paths ~f:(fun glob -> Dunolint.Glob.test glob path)))
-;;
-
 let lint_file
       (module File_linter : Dunolinter.S)
       ~format_file
@@ -233,7 +208,7 @@ let main =
        | None -> In_channel.input_all In_channel.stdin
      in
      let output =
-       if skip_file ~context ~path
+       if Linter.should_skip_subtree ~context ~path
        then original_contents
        else lint_file linter ~format_file ~context ~path ~original_contents
      in

--- a/lib/dunolint_cli/src/linter.ml
+++ b/lib/dunolint_cli/src/linter.ml
@@ -88,16 +88,7 @@ let lint_stanza ~context ~stanza ~(return : _ With_return.return) =
       (* [Context.configs] returns configs in processing order: shallowest to
          deepest, so deeper configs can override shallower ones. *)
       List.iter (Dunolint_engine.Context.configs context) ~f:(fun config ->
-        let rules = Dunolint.Config.rules config in
-        List.iter rules ~f:(fun rule ->
-          if false
-          then
-            Err.debug
-              ~loc
-              (lazy
-                [ Pp.text "Applying rule"
-                ; Err.sexp [%sexp (rule : Dunolint.Config.Rule.t)]
-                ]) [@coverage off];
+        List.iter (Dunolint.Config.rules config) ~f:(fun rule ->
           match Dunolint.Rule.eval rule ~f:eval with
           | `return -> ()
           | `enforce condition -> enforce condition

--- a/lib/dunolint_cli/src/linter.ml
+++ b/lib/dunolint_cli/src/linter.ml
@@ -148,18 +148,18 @@ let visit_directory ~dunolint_engine ~context ~parent_dir ~files =
     let rec loop = function
       | [] -> Dunolint_engine.Visitor_decision.Continue
       | file :: files ->
-        let path = Relative_path.extend parent_dir (Fsegment.v file) in
         (match
-           if should_skip_file ~context ~path
-           then Visitor_decision.Continue
-           else (
-             match Dunolint.Linted_file_kind.of_string file with
-             | Error (`Msg _) -> Visitor_decision.Continue
-             | Ok linted_file_kind ->
-               (match linted_file_kind with
-                | `dune -> Dune_lint.lint_file ~dunolint_engine ~context ~path
-                | `dune_project ->
-                  Dune_project_lint.lint_file ~dunolint_engine ~context ~path))
+           match Dunolint.Linted_file_kind.of_string file with
+           | Error (`Msg _) -> Visitor_decision.Continue
+           | Ok linted_file_kind ->
+             let path = Relative_path.extend parent_dir (Fsegment.v file) in
+             if should_skip_file ~context ~path
+             then Visitor_decision.Continue
+             else (
+               match linted_file_kind with
+               | `dune -> Dune_lint.lint_file ~dunolint_engine ~context ~path
+               | `dune_project ->
+                 Dune_project_lint.lint_file ~dunolint_engine ~context ~path)
          with
          | Continue -> loop files
          | Skip_subtree -> Dunolint_engine.Visitor_decision.Skip_subtree)

--- a/lib/dunolint_cli/src/linter.ml
+++ b/lib/dunolint_cli/src/linter.ml
@@ -21,6 +21,31 @@
 
 open! Import
 
+let should_skip_subtree ~context ~(path : Relative_path.t) =
+  let paths_to_check_for_skip_predicates =
+    Path_in_workspace.paths_to_check_for_skip_predicates ~path
+  in
+  List.exists (Dunolint_engine.Context.configs context) ~f:(fun config ->
+    match Dunolint.Config.Private.view config with
+    | `v0 v0 ->
+      (match Dunolint.Config.V0.skip_subtree v0 with
+       | None -> false
+       | Some condition ->
+         List.exists paths_to_check_for_skip_predicates ~f:(fun path ->
+           match
+             Dunolint.Rule.eval condition ~f:(fun (`path condition) ->
+               Dunolinter.eval_path ~path ~condition)
+           with
+           | `enforce _ -> .
+           | `return -> false
+           | `skip_subtree -> true))
+    | `v1 v1 ->
+      let skip_paths = Dunolint.Config.V1.skip_paths v1 |> List.concat in
+      List.exists paths_to_check_for_skip_predicates ~f:(fun path ->
+        let path = Relative_path.to_string path in
+        List.exists skip_paths ~f:(fun glob -> Dunolint.Glob.test glob path)))
+;;
+
 let maybe_autoformat_file ~previous_contents ~new_contents =
   (* For the time being we are using here a heuristic to drive whether to
      autoformat linted files. This is motivated by pragmatic reasoning and lower
@@ -116,32 +141,7 @@ module Dune_lint = Lint_file (Dune_linter)
 module Dune_project_lint = Lint_file (Dune_project_linter)
 
 let visit_directory ~dunolint_engine ~context ~parent_dir ~files =
-  let paths_to_check_for_skip_predicates =
-    Path_in_workspace.paths_to_check_for_skip_predicates ~path:parent_dir
-  in
-  (* Check skip_subtree across all configs in context. *)
-  let should_skip_subtree =
-    List.exists (Dunolint_engine.Context.configs context) ~f:(fun config ->
-      match Dunolint.Config.Private.view config with
-      | `v0 v0 ->
-        (match Dunolint.Config.V0.skip_subtree v0 with
-         | None -> false
-         | Some condition ->
-           List.exists paths_to_check_for_skip_predicates ~f:(fun parent_dir ->
-             match
-               Dunolint.Rule.eval condition ~f:(fun (`path condition) ->
-                 Dunolinter.eval_path ~path:parent_dir ~condition)
-             with
-             | `enforce _ -> .
-             | `return -> false
-             | `skip_subtree -> true))
-      | `v1 v1 ->
-        let skip_subtrees = Dunolint.Config.V1.skip_paths v1 |> List.concat in
-        List.exists paths_to_check_for_skip_predicates ~f:(fun parent_dir ->
-          let parent_dir = Relative_path.to_string parent_dir in
-          List.exists skip_subtrees ~f:(fun glob -> Dunolint.Glob.test glob parent_dir)))
-  in
-  match should_skip_subtree with
+  match should_skip_subtree ~context ~path:parent_dir with
   | true -> Dunolint_engine.Visitor_decision.Skip_subtree
   | false ->
     let rec loop = function

--- a/lib/dunolint_cli/src/linter.mli
+++ b/lib/dunolint_cli/src/linter.mli
@@ -19,6 +19,11 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.         *)
 (*_********************************************************************************)
 
+val should_skip_subtree
+  :  context:Dunolint_engine.Context.t
+  -> path:Relative_path.t
+  -> bool
+
 val maybe_autoformat_file : previous_contents:string -> new_contents:string -> string
 
 val lint_stanza

--- a/lib/dunolint_cli/src/linter.mli
+++ b/lib/dunolint_cli/src/linter.mli
@@ -27,7 +27,8 @@ val should_skip_subtree
 val maybe_autoformat_file : previous_contents:string -> new_contents:string -> string
 
 val lint_stanza
-  :  context:Dunolint_engine.Context.t
+  :  path:Relative_path.t
+  -> context:Dunolint_engine.Context.t
   -> stanza:'a Dunolinter.Stanza.t
   -> return:[> `skip_subtree ] With_return.return
   -> unit

--- a/lib/dunolinter/src/dunolinter_intf.mli
+++ b/lib/dunolinter/src/dunolinter_intf.mli
@@ -50,13 +50,11 @@ module type S = sig
 
   (** {1 Creation} *)
 
-  (** A [t] shall be created from a string that would yield a
-      successful parsing of many sexps and positions from a dune file,
-      using the [Parsexp] library. The [path] is provided to create a
-      [Loc.t] for error messages, as well as serve during condition
-      evaluation based on paths, but no I/O is actually performed on
-      disk - the sexps are parsed from the string provided by the
-      parameter [original_contents].
+  (** A [t] shall be created from a string that would yield a successful parsing
+      of many sexps and positions from a dune file, using the [Parsexp] library.
+      The [path] is provided to create a [Loc.t] for error messages, but no I/O
+      is actually performed on disk - the sexps are parsed from the string
+      provided by the parameter [original_contents].
 
       The type is intended to make it easy to connect to code using
       [Err], such as shown below:

--- a/lib/dunolinter/src/dunolinter_intf.mli
+++ b/lib/dunolinter/src/dunolinter_intf.mli
@@ -22,29 +22,27 @@
 module type S = sig
   (** A linter for a file containing stanzas.
 
-      A value of type [t] holds enough capability to handle in
-      sequence the linting of all the stanzas contained in a single
-      file. *)
+      A value of type [t] holds enough capability to handle in sequence the
+      linting of all the stanzas contained in a single file. *)
 
-  (** The type t will usually be mutable. A typical life cycle for it
-      is to be created, then some side effects are performed on it due
-      to the application of linting rules. At the end, we create the
-      linted contents of the result. *)
+  (** The type t will usually be mutable. A typical life cycle for it is to be
+      created, then some side effects are performed on it due to the application
+      of linting rules. At the end, we create the linted contents of the
+      result. *)
   type t
 
-  (** This type will be available as ['a Dunolinter.Stanza.t] however it
-      is needed here in this interface to avoid a circular dependency.
-      This is the type for the stanza that will be iterated on during
-      linting. *)
+  (** This type will be available as ['a Dunolinter.Stanza.t] however it is
+      needed here in this interface to avoid a circular dependency. This is the
+      type for the stanza that will be iterated on during linting. *)
   type 'a stanza
 
   (** {1 Stanzas} *)
 
   module Stanza : sig
-    (** [t] is extensible so it is easier to extend it in future versions
-        of [dunolint] while maintaining better compatibility with user
-        code, which shall embrace the fact that they shall handle stanzas
-        that are not parsed by the tool. *)
+    (** [t] is extensible so it is easier to extend it in future versions of
+        [dunolint] while maintaining better compatibility with user code, which
+        shall embrace the fact that they shall handle stanzas that are not
+        parsed by the tool. *)
     type t = private ..
   end
 
@@ -56,8 +54,8 @@ module type S = sig
       is actually performed on disk - the sexps are parsed from the string
       provided by the parameter [original_contents].
 
-      The type is intended to make it easy to connect to code using
-      [Err], such as shown below:
+      The type is intended to make it easy to connect to code using [Err], such
+      as shown below:
 
       {[
         match Dune_linter.create ~path ~original_contents with
@@ -71,47 +69,44 @@ module type S = sig
 
   (** {1 Linting} *)
 
-  (** Iter through the stanzas found in the file. The function [f]
-      provided will be called on all the toplevel stanzas found in the
-      file.
+  (** Iter through the stanzas found in the file. The function [f] provided will
+      be called on all the toplevel stanzas found in the file.
 
-      The expected way to use this function is to do some pattern
-      matching on the [Stanza.t] currently at hand, and use the
-      corresponding api if some rewrites are required. If the current
-      stanza is not one you are targeting you may simply ignore and
-      return unit, to be called again on the remaining stanzas of the
-      input.
+      The expected way to use this function is to do some pattern matching on
+      the [Stanza.t] currently at hand, and use the corresponding api if some
+      rewrites are required. If the current stanza is not one you are targeting
+      you may simply ignore and return unit, to be called again on the remaining
+      stanzas of the input.
 
-      Note that you may visit the same file multiple times (that is,
-      calling [visit] multiple times with different invocations of [f]),
-      however be mindful that the [file_rewriter] that you manipulate is
-      the same each time, thus the final computation of the output will
-      fail if you enqueue incompatible rewrites in it. This is however
-      not a recommended way to use this library, as this may be quite
-      confusing. Indeed, the state you will match on will be that of the
-      original contents, even though some rewrites have already happen.
-      It shall be preferred to apply all the rewrites you wish in one
-      path for each stanza, unless you are sure the rewrites are
+      Note that you may visit the same file multiple times (that is, calling
+      [visit] multiple times with different invocations of [f]), however be
+      mindful that the [file_rewriter] that you manipulate is the same each
+      time, thus the final computation of the output will fail if you enqueue
+      incompatible rewrites in it. This is however not a recommended way to use
+      this library, as this may be quite confusing. Indeed, the state you will
+      match on will be that of the original contents, even though some rewrites
+      have already happen. It shall be preferred to apply all the rewrites you
+      wish in one path for each stanza, unless you are sure the rewrites are
       targeting parts of the input that are clearly independent.
 
       If you need to apply low-level rewrites, you may do so with the
-      [Sexps_rewriter] api, by accessing the [original_sexp] of the
-      stanza. For example, you can do so with stanzas or rewrites that
-      are not natively supported by this library. *)
+      [Sexps_rewriter] api, by accessing the [original_sexp] of the stanza. For
+      example, you can do so with stanzas or rewrites that are not natively
+      supported by this library. *)
   val visit : t -> f:(Stanza.t stanza -> unit) -> unit
 
   (** {1 Output} *)
 
   (** Produce the resulting buffer, with all the rewrites applied. Note that [t]
       may continue to be used further from here, and you can call [contents]
-      again later. This raises [File_rewriter.Invalid_rewrites] if
-      inconsistent rewrites have been submitted to t's [file_rewriter].
+      again later. This raises [File_rewriter.Invalid_rewrites] if inconsistent
+      rewrites have been submitted to t's [file_rewriter].
 
-      Note that this library is a rather low-level util library. In
-      particular, using this library does not get you auto-formatting of
-      dune files, thus the output may be not particularly pretty or well
-      indented. For a more ergonomic wrapper, and inclusion of auto-fmt,
-      you should consider using via [Dunolint_engine]. *)
+      Note that this library is a rather low-level util library. In particular,
+      using this library does not get you auto-formatting of dune files, thus
+      the output may be not particularly pretty or well indented. For a more
+      ergonomic wrapper, and inclusion of auto-fmt, you should consider using
+      via [Dunolint_engine]. *)
   val contents : t -> string
 
   (** {1 Getters} *)

--- a/lib/dunolinter/src/linter.ml
+++ b/lib/dunolinter/src/linter.ml
@@ -24,8 +24,9 @@ module type S = Linter_intf.S
 type t =
   | Unhandled
   | T :
-      { eval : Dunolint.Predicate.t -> Dunolint.Trilang.t
-      ; enforce : Dunolint.Predicate.t Blang.t -> unit
+      { eval :
+          path:Relative_path.t -> predicate:Dunolint.Predicate.t -> Dunolint.Trilang.t
+      ; enforce : path:Relative_path.t -> condition:Dunolint.Predicate.t Blang.t -> unit
       }
       -> t
 

--- a/lib/dunolinter/src/linter.mli
+++ b/lib/dunolinter/src/linter.mli
@@ -24,8 +24,9 @@ module type S = Linter_intf.S
 type t =
   | Unhandled
   | T :
-      { eval : Dunolint.Predicate.t -> Dunolint.Trilang.t
-      ; enforce : Dunolint.Predicate.t Blang.t -> unit
+      { eval :
+          path:Relative_path.t -> predicate:Dunolint.Predicate.t -> Dunolint.Trilang.t
+      ; enforce : path:Relative_path.t -> condition:Dunolint.Predicate.t Blang.t -> unit
       }
       -> t
 


### PR DESCRIPTION
Various refactor to prepare for qualified located path.

> With the introduction of located configs, the path used for evaluation will need to be the path relative to where the rules where loaded, rather than the path from the root of the workspace.