### PR TITLE
Implement dunolint config files autoloading

### DIFF
--- a/lib/dunolint/test/test__glob.ml
+++ b/lib/dunolint/test/test__glob.ml
@@ -122,6 +122,24 @@ let%expect_test "test" =
   [%expect {| (is_match false) |}];
   test g "_build/";
   [%expect {| (is_match false) |}];
+  let g = Glob.v "**" in
+  test g "file";
+  [%expect {| (is_match true) |}];
+  test g "foo/file";
+  [%expect {| (is_match true) |}];
+  test g "./";
+  [%expect {| (is_match false) |}];
+  test g ".";
+  [%expect {| (is_match false) |}];
+  let g = Glob.v "*" in
+  test g "file";
+  [%expect {| (is_match true) |}];
+  test g "foo/file";
+  [%expect {| (is_match false) |}];
+  test g "./";
+  [%expect {| (is_match false) |}];
+  test g ".";
+  [%expect {| (is_match false) |}];
   ()
 ;;
 

--- a/lib/dunolint_cli/src/common_helpers.ml
+++ b/lib/dunolint_cli/src/common_helpers.ml
@@ -74,18 +74,6 @@ let enforce_rules_config ~rules =
        |> Dunolint.Config.v1)
 ;;
 
-let load_config_opt ~config =
-  match config with
-  | Some filename -> Some (Dunolinter.Config_handler.load_config_exn ~filename)
-  | None ->
-    let cwd = Unix.getcwd () |> Absolute_path.v in
-    let default_file = Absolute_path.extend cwd (Fsegment.v "dunolint") in
-    let filename = Absolute_path.to_string default_file in
-    if Stdlib.Sys.file_exists filename
-    then Some (Dunolinter.Config_handler.load_config_exn ~filename:"dunolint")
-    else None
-;;
-
 let root =
   let open Command.Std in
   let+ root =

--- a/lib/dunolint_engine/src/config_cache.ml
+++ b/lib/dunolint_engine/src/config_cache.ml
@@ -1,0 +1,91 @@
+(*********************************************************************************)
+(*  Dunolint - A tool to lint and help manage files in dune projects             *)
+(*  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>            *)
+(*                                                                               *)
+(*  This file is part of Dunolint.                                               *)
+(*                                                                               *)
+(*  Dunolint is free software; you can redistribute it and/or modify it          *)
+(*  under the terms of the GNU Lesser General Public License as published by     *)
+(*  the Free Software Foundation either version 3 of the License, or any later   *)
+(*  version, with the LGPL-3.0 Linking Exception.                                *)
+(*                                                                               *)
+(*  Dunolint is distributed in the hope that it will be useful, but WITHOUT      *)
+(*  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or        *)
+(*  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License  *)
+(*  and the file `NOTICE.md` at the root of this repository for more details.    *)
+(*                                                                               *)
+(*  You should have received a copy of the GNU Lesser General Public License     *)
+(*  and the LGPL-3.0 Linking Exception along with this library. If not, see      *)
+(*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.         *)
+(*********************************************************************************)
+
+let src = Logs.Src.create "dunolint" ~doc:"dunolint"
+
+module Load_result = struct
+  type t =
+    | Absent
+    | Present of Dunolint.Config.t
+    | Error of Err.t
+end
+
+type t = Load_result.t Hashtbl.M(Relative_path).t
+
+let create () : t = Hashtbl.create (module Relative_path)
+
+let load_config_in_dir (t : t) ~dir : Load_result.t =
+  let config_path = Relative_path.extend dir (Fsegment.v "dunolint") in
+  match Hashtbl.find t config_path with
+  | Some result ->
+    (* CR-soon mbarbin: At the moment we haven't exercised in tests execution
+       paths where the cache is useful. This is left as follow-up work. *)
+    result
+    [@coverage off]
+  | None ->
+    let result : Load_result.t =
+      match
+        match (Unix.stat (Relative_path.to_string config_path)).st_kind with
+        | exception Unix.Unix_error (ENOENT, _, _) -> `Absent
+        | file_kind ->
+          (match[@coverage off] file_kind with
+           | S_REG | S_LNK -> `Present
+           | S_DIR | S_CHR | S_BLK | S_FIFO | S_SOCK -> `Not_a_file)
+      with
+      | `Absent | `Not_a_file ->
+        Log.debug ~src (fun () ->
+          Pp.O.
+            [ Pp.text "Config file does not exist at "
+              ++ Pp_tty.path (module Relative_path) config_path
+              ++ Pp.text "."
+            ]);
+        Absent
+      | `Present ->
+        (try
+           let config =
+             Dunolinter.Config_handler.load_config_exn
+               ~filename:(Relative_path.to_string config_path)
+           in
+           Log.info ~src (fun () ->
+             Pp.O.
+               [ Pp.text "Loaded dunolint config from "
+                 ++ Pp_tty.path (module Relative_path) config_path
+                 ++ Pp.text "."
+               ]);
+           Present config
+         with
+         | Err.E err -> Error err
+         | exn ->
+           (let err =
+              Err.create
+                Pp.O.
+                  [ Pp.textf "Failed to load config at "
+                    ++ Pp_tty.path (module Relative_path) config_path
+                    ++ Pp.text "."
+                  ; Err.exn exn
+                  ]
+            in
+            Error err)
+           [@coverage off])
+    in
+    Hashtbl.set t ~key:config_path ~data:result;
+    result
+;;

--- a/lib/dunolint_engine/src/config_cache.mli
+++ b/lib/dunolint_engine/src/config_cache.mli
@@ -19,34 +19,16 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.         *)
 (*_********************************************************************************)
 
-(** For use in the rest of the files in this directory. *)
+(** Cache for loaded configs to avoid re-parsing the same file multiple times. *)
 
-val sexpable_param : (module Sexpable.S with type t = 'a) -> 'a Command.Param.t
+module Load_result : sig
+  type t =
+    | Absent
+    | Present of Dunolint.Config.t
+    | Error of Err.t
+end
 
-(** Restrict the scope of a command to a subdirectory only. "Below this path".
-    Accepts both relative and absolute paths. *)
-val below : doc:string -> Fpath.t option Command.Arg.t
+type t
 
-(** A list of defaults directories to skip. *)
-val skip_subtrees : globs:string list -> Dunolint.Glob.t list
-
-(** Create a default config with only skip_paths for common directories. *)
-val default_skip_paths_config : unit -> Dunolint.Config.t
-
-(** Create a config containing only the given enforce rules, or None if the list
-    is empty. *)
-val enforce_rules_config : rules:Dunolint.Config.Rule.t list -> Dunolint.Config.t option
-
-(** Override the workspace root - same as with dune. *)
-val root : Absolute_path.t option Command.Arg.t
-
-(** When supplying path arguments that are aimed to designate paths in
-    workspace, we need to resolve them according to where the [workspace_root]
-    is in relation to the cwd. We interpret relative paths as relative to the
-    [cwd] from which the program started. We use this helper for example to
-    resolve arguments such as [--below _] or [--config _]. *)
-val relativize
-  :  workspace_root:Workspace_root.t
-  -> cwd:Absolute_path.t
-  -> path:Fpath.t
-  -> Relative_path.t
+val create : unit -> t
+val load_config_in_dir : t -> dir:Relative_path.t -> Load_result.t

--- a/lib/dunolint_engine/src/context.ml
+++ b/lib/dunolint_engine/src/context.ml
@@ -19,8 +19,15 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.         *)
 (*********************************************************************************)
 
+module Config_with_location = struct
+  type t =
+    { config : Dunolint.Config.t
+    ; location : Relative_path.t
+    }
+end
+
 module Item = struct
-  type t = Config of Dunolint.Config.t
+  type t = Config of Config_with_location.t
 end
 
 type t = Item.t list
@@ -34,4 +41,4 @@ let configs (t : t) =
   List.rev_map t ~f:(function Config config -> config)
 ;;
 
-let add_config t ~config = Item.Config config :: t
+let add_config t ~config ~location = Item.Config { config; location } :: t

--- a/lib/dunolint_engine/src/context.mli
+++ b/lib/dunolint_engine/src/context.mli
@@ -48,11 +48,21 @@ type t
 (** An empty context. *)
 val empty : t
 
-(** Add a config to the context. *)
-val add_config : t -> config:Dunolint.Config.t -> t
+(** Configuration with its location in the directory tree. *)
+module Config_with_location : sig
+  type t =
+    { config : Dunolint.Config.t
+    ; location : Relative_path.t
+      (** Directory where this config was found
+          relative to the workspace root. *)
+    }
+end
 
-(** Get the list of configs in the context. Returns configs in rule processing
-    order: from least specific (root) to most specific (closest to current
-    location), so that deeper configs can override rules from shallower
-    configs. *)
-val configs : t -> Dunolint.Config.t list
+(** Add a discovered config at the specified location. *)
+val add_config : t -> config:Dunolint.Config.t -> location:Relative_path.t -> t
+
+(** Get the list of discovered configs with their locations.
+    Returns configs in rule processing order: from least specific (root) to
+    most specific (closest to current location), so that deeper configs can
+    override rules from shallower configs. *)
+val configs : t -> Config_with_location.t list

--- a/lib/dunolint_engine/src/dunolint_engine.mli
+++ b/lib/dunolint_engine/src/dunolint_engine.mli
@@ -47,19 +47,19 @@ val build_context : t -> path:Relative_path.t -> Context.t
 (** {1 Execution control}*)
 
 module Visitor_decision : sig
-  (** While we visit the repository, we may decide what to do at each step of the
-      iteration. *)
+  (** While we visit the repository, we may decide what to do at each step of
+      the iteration. *)
 
   type t =
     | Break (** Stops the current execution of [visit]. *)
     | Continue
-    (** Recurse and visit the children of the current sexp if any, or
-        continue with the next directory in the queue. *)
+    (** Recurse and visit the children of the current sexp if any, or continue
+        with the next directory in the queue. *)
     | Skip_subtree
-    (** Do not drill in, skip the current directory and continue
-        with the next directory in the queue. If the current directory
-        does not have subdirectory, this is equivalent to [Continue],
-        which should be preferred by default. *)
+    (** Do not drill in, skip the current directory and continue with the next
+        directory in the queue. If the current directory does not have
+        subdirectory, this is equivalent to [Continue], which should be
+        preferred by default. *)
 end
 
 (** Visit the directory tree.
@@ -120,8 +120,8 @@ val lint_file
   -> unit
 
 (** Spawn a [dune format-dune-file] on the new linted contents before
-    materializing into a file. Exposed if you need to write your own linters
-    on files that are supported by the formatter shipped with dune. *)
+    materializing into a file. Exposed if you need to write your own linters on
+    files that are supported by the formatter shipped with dune. *)
 val format_dune_file : new_contents:string -> string
 
 (** This calls [f] once, registers all requests enqueued during the execution of
@@ -171,7 +171,7 @@ module Private : sig
 
   (** Path operations for workspace-relative paths with escaping prevention.
 
-      This module is exported for testing purposes. See
-      {!Path_in_workspace} for documentation. *)
+      This module is exported for testing purposes. See {!Path_in_workspace} for
+      documentation. *)
   module Path_in_workspace = Path_in_workspace
 end

--- a/lib/test_helpers/src/test_helpers.ml
+++ b/lib/test_helpers/src/test_helpers.ml
@@ -59,6 +59,7 @@ let run_linter ~config =
   let () =
     Dunolint_engine.visit
       dunolint_engine
+      ~autoload_config:false
       ~f:(fun ~context ~parent_dir ~subdirectories:_ ~files ->
         Dunolint_cli.Private.Linter.visit_directory
           ~dunolint_engine

--- a/test/cram/check.t
+++ b/test/cram/check.t
@@ -31,11 +31,15 @@ Let's do some linting!
 
   $ dunolint lint --check --verbosity=debug
   dunolint: [DEBUG] Visiting directory "./"
+  dunolint: [DEBUG] Config file does not exist at "dunolint".
   dunolint: [INFO] Linting file "dune-project"
   dunolint: [DEBUG] Visiting directory "_build/"
-  dunolint: [INFO] Skipping children of directory "_build/"
+  dunolint: [DEBUG] Config file does not exist at "_build/dunolint".
+  dunolint: [INFO] Skipping directory "_build/"
   dunolint: [DEBUG] Visiting directory "lib/"
+  dunolint: [DEBUG] Config file does not exist at "lib/dunolint".
   dunolint: [DEBUG] Visiting directory "lib/foo/"
+  dunolint: [DEBUG] Config file does not exist at "lib/foo/dunolint".
   dunolint: [INFO] Linting file "lib/foo/dune"
 
 Now let's suppose there are some lints to apply. We'll add manual conditions to

--- a/test/cram/config-auto-discovery.t
+++ b/test/cram/config-auto-discovery.t
@@ -1,0 +1,181 @@
+Test automatic discovery of dunolint config files in subdirectories without root config.
+
+Create a workspace with no root config, only subdirectory configs:
+
+  $ touch dune-workspace
+  $ cat > dune-project << EOF
+  > (lang dune 3.0)
+  > (name test_project)
+  > EOF
+
+Create a library at root with no special requirements:
+
+  $ cat > dune << EOF
+  > (library
+  >  (name root_lib))
+  > EOF
+
+Create src/ directory with a config that enforces library names start with "src_":
+
+  $ mkdir -p src
+  $ cat > src/dunolint << EOF
+  > (lang dunolint 1.0)
+  > 
+  > (rule
+  >  (cond
+  >   ((path (glob **)) (enforce (dune (library (name (is_prefix src_))))))))
+  > EOF
+
+  $ cat > src/dune << EOF
+  > (library
+  >  (name src_lib))
+  > EOF
+
+Create src/public/ without its own config (inherits from src/):
+
+  $ mkdir -p src/public
+  $ cat > src/public/dune << EOF
+  > (library
+  >  (name src_public_lib))
+  > EOF
+
+Create tests/ directory with a config that enforces library names start with "test_":
+
+  $ mkdir -p tests
+  $ cat > tests/dunolint << EOF
+  > (lang dunolint 1.0)
+  > 
+  > (rule
+  >  (cond
+  >   ((path (glob **)) (enforce (dune (library (name (is_prefix test_))))))))
+  > EOF
+
+  $ cat > tests/dune << EOF
+  > (library
+  >  (name test_lib))
+  > EOF
+
+Running from root with no root config discovers subdirectory configs:
+
+  $ dunolint lint --dry-run -v 2>&1
+  dunolint: [INFO] Linting file "dune"
+  dunolint: [INFO] Linting file "dune-project"
+  dunolint: [INFO] Loaded dunolint config from "src/dunolint".
+  dunolint: [INFO] Linting file "src/dune"
+  dunolint: [INFO] Linting file "src/public/dune"
+  dunolint: [INFO] Loaded dunolint config from "tests/dunolint".
+  dunolint: [INFO] Linting file "tests/dune"
+
+Linting only src/ directory uses src/dunolint config:
+
+  $ dunolint lint --dry-run --below src -v 2>&1
+  dunolint: [INFO] Loaded dunolint config from "src/dunolint".
+  dunolint: [INFO] Linting file "src/dune"
+  dunolint: [INFO] Linting file "src/public/dune"
+
+Linting only tests/ directory uses tests/dunolint config:
+
+  $ dunolint lint --dry-run --below tests -v 2>&1
+  dunolint: [INFO] Loaded dunolint config from "tests/dunolint".
+  dunolint: [INFO] Linting file "tests/dune"
+
+Verify configs accumulate (child configs don't replace parent):
+
+  $ mkdir -p multi/level
+  $ cat > multi/dunolint << EOF
+  > (lang dunolint 1.0)
+  > 
+  > (rule
+  >  (cond
+  >   ((path (glob **)) (enforce (dune (library (has_field name)))))))
+  > EOF
+
+  $ cat > multi/level/dunolint << EOF
+  > (lang dunolint 1.0)
+  > 
+  > (rule
+  >  (cond
+  >   ((path (glob **)) (enforce (dune (library (has_field public_name)))))))
+  > EOF
+
+  $ cat > multi/level/dune << EOF
+  > (library)
+  > EOF
+
+Both configs should apply (name from parent, public_name from local):
+
+  $ dunolint lint --dry-run --below multi 2>&1
+  File "multi/level/dune", line 1, characters 0-9:
+  1 | (library)
+      ^^^^^^^^^
+  Error: Enforce Failure.
+  The following condition does not hold: (has_field name)
+  Dunolint is able to suggest automatic modifications to satisfy linting rules
+  when a strategy is implemented, however in this case there is none available.
+  Hint: You need to attend and fix manually.
+  
+  File "multi/level/dune", line 1, characters 0-9:
+  1 | (library)
+      ^^^^^^^^^
+  Error: Enforce Failure.
+  The following condition does not hold: (has_field public_name)
+  Dunolint is able to suggest automatic modifications to satisfy linting rules
+  when a strategy is implemented, however in this case there is none available.
+  Hint: You need to attend and fix manually.
+  [123]
+
+Invalid config causes directory to be skipped with error:
+
+  $ mkdir -p invalid/subdir
+  $ cat > invalid/dunolint << EOF
+  > (invalid syntax here)
+  > EOF
+
+  $ cat > invalid/dune << EOF
+  > (library
+  >  (name should_be_skipped))
+  > EOF
+
+  $ cat > invalid/subdir/dune << EOF
+  > (library
+  >  (name also_skipped))
+  > EOF
+
+The directory with invalid config should be skipped:
+
+  $ dunolint lint --dry-run 2>&1
+  File "invalid/dunolint", line 1, characters 0-21:
+  1 | (invalid syntax here)
+      ^^^^^^^^^^^^^^^^^^^^^
+  Error: Dunolint config expected to start with (lang dunolint VERSION).
+  
+  File "multi/level/dune", line 1, characters 0-9:
+  1 | (library)
+      ^^^^^^^^^
+  Error: Enforce Failure.
+  The following condition does not hold: (has_field name)
+  Dunolint is able to suggest automatic modifications to satisfy linting rules
+  when a strategy is implemented, however in this case there is none available.
+  Hint: You need to attend and fix manually.
+  
+  File "multi/level/dune", line 1, characters 0-9:
+  1 | (library)
+      ^^^^^^^^^
+  Error: Enforce Failure.
+  The following condition does not hold: (has_field public_name)
+  Dunolint is able to suggest automatic modifications to satisfy linting rules
+  when a strategy is implemented, however in this case there is none available.
+  Hint: You need to attend and fix manually.
+  [123]
+
+  $ dunolint lint --below invalid --dry-run 2>&1
+  File "invalid/dunolint", line 1, characters 0-21:
+  1 | (invalid syntax here)
+      ^^^^^^^^^^^^^^^^^^^^^
+  Error: Dunolint config expected to start with (lang dunolint VERSION).
+  [123]
+
+Test that the files in the invalid directory are not linted:
+
+  $ dunolint lint --dry-run -v 2>&1 | grep "Linting file.*invalid"
+  [1]

--- a/test/cram/dunolint-directory.t
+++ b/test/cram/dunolint-directory.t
@@ -1,0 +1,26 @@
+Test that a directory named `dunolint` doesn't create a config discovery issue.
+
+  $ touch dune-workspace
+
+  $ mkdir -p dunolint
+
+  $ cat > dunolint/dunolint << EOF
+  > (lang dunolint 1.0)
+  > 
+  > (rule (enforce (dune_project (name (equals dunolint)))))
+  > EOF
+
+  $ cat > dunolint/dune-project << EOF
+  > (lang dune 3.18)
+  > 
+  > (name test)
+  > EOF
+
+  $ dunolint lint
+  Editing file "dunolint/dune-project":
+  -1,3 +1,3
+    (lang dune 3.18)
+    
+  -|(name test)
+  +|(name dunolint)
+

--- a/test/cram/interactive.t
+++ b/test/cram/interactive.t
@@ -61,6 +61,21 @@ Note it is possible to restrict the run to a subdirectory only.
   -| (name bar))
   +| (name foo))
 
+Run the same command in debug mode to visualize configs and directories loaded.
+
+  $ dunolint lint --dry-run --below lib/ --log-level=debug
+  dunolint: [INFO] Loaded dunolint config from "dunolint".
+  dunolint: [DEBUG] Visiting directory "lib/"
+  dunolint: [DEBUG] Config file does not exist at "lib/dunolint".
+  dunolint: [DEBUG] Visiting directory "lib/foo/"
+  dunolint: [DEBUG] Config file does not exist at "lib/foo/dunolint".
+  dunolint: [INFO] Linting file "lib/foo/dune"
+  dry-run: Would edit file "lib/foo/dune":
+  -1,2 +1,2
+    (library
+  -| (name bar))
+  +| (name foo))
+
 Interactive run.
 
 We disable the pager for the test.

--- a/test/cram/interactive.t
+++ b/test/cram/interactive.t
@@ -25,7 +25,7 @@ Where this is nothing to lint, the interactive command exits with no prompt.
 
   $ dunolint lint --interactive --verbose
   dunolint: [INFO] Linting file "dune-project"
-  dunolint: [INFO] Skipping children of directory "_build/"
+  dunolint: [INFO] Skipping directory "_build/"
   dunolint: [INFO] Linting file "lib/foo/dune"
 
 Let's create a config with some rules that are going to apply to the files we

--- a/test/cram/lint.t
+++ b/test/cram/lint.t
@@ -43,7 +43,17 @@ If a loaded config is invalid, dunolint will report an error.
 
   $ printf '(blah)\n' > dunolint
 
-  $ dunolint lint --yes
+  $ dunolint lint --dry-run -v
+  File "dunolint", line 1, characters 0-6:
+  1 | (blah)
+      ^^^^^^
+  Error: Dunolint config expected to start with (lang dunolint VERSION).
+  dunolint: [INFO] Skipping directory due to invalid config: "./"
+  [123]
+
+This would also apply when loading invalid parent config via discovery.
+
+  $ dunolint lint --dry-run -v --below vendor/
   File "dunolint", line 1, characters 0-6:
   1 | (blah)
       ^^^^^^

--- a/test/cram/lint.t
+++ b/test/cram/lint.t
@@ -39,7 +39,7 @@ its own. See below how the name of the project is not linted:
 
   $ dunolint lint --yes
 
-If the config is supplied, but it is invalid, dunolint will complain.
+If a loaded config is invalid, dunolint will report an error.
 
   $ printf '(blah)\n' > dunolint
 

--- a/test/cram/path-resolution-relative-to-config.t
+++ b/test/cram/path-resolution-relative-to-config.t
@@ -1,0 +1,56 @@
+Test that path predicates in rules are evaluated relative to config location.
+
+When a config at lib/dunolint contains a rule with (path (glob alpha/**)),
+the glob should be evaluated relative to lib/, not the workspace root.
+This ensures that hierarchical configs can use path patterns that are
+meaningful relative to their own location in the directory tree.
+
+Setup workspace:
+
+  $ touch dune-workspace
+  $ cat > dune-project << EOF
+  > (lang dune 3.0)
+  > (name test_project)
+  > EOF
+
+Create lib/ directory with a config:
+
+  $ mkdir -p lib
+  $ cat > lib/dunolint << EOF
+  > (lang dunolint 1.0)
+  > 
+  > (rule
+  >  (cond
+  >   ((path (glob alpha/**)) (enforce (dune (library (name (is_prefix alpha_))))))))
+  > EOF
+
+Create lib/alpha/ and lib/beta/ directories:
+
+  $ mkdir -p lib/alpha lib/beta lib/alpha/nested
+  $ cat > lib/alpha/dune << EOF
+  > (library
+  >  (name alpha_lib))
+  > EOF
+
+  $ cat > lib/beta/dune << EOF
+  > (library
+  >  (name beta_lib))
+  > EOF
+
+  $ cat > lib/alpha/nested/dune << EOF
+  > (library
+  >  (name nested_lib))
+  > EOF
+
+The rule should apply to files matching alpha/** (relative to lib/):
+- lib/alpha/dune should match (path alpha/dune) - already has alpha_ prefix
+- lib/alpha/nested/dune should match (path alpha/nested/dune) - needs alpha_ prefix
+- lib/beta/dune should NOT match (path beta/dune)
+
+Run lint:
+
+  $ dunolint lint --dry-run
+  dry-run: Would edit file "lib/alpha/nested/dune":
+  -1,2 +1,2
+    (library
+  !| (name alpha_nested_lib))


### PR DESCRIPTION
 Now automatically load `dunolint` config files discovered while traversing the tree to lint files.

This implements the feature discussed in #41 .