### PR TITLE
Remove compare functions from Predicate modules

### DIFF
--- a/src/dunolint-lib/dunolint/condition.ml
+++ b/src/dunolint-lib/dunolint/condition.ml
@@ -24,11 +24,6 @@ module T = struct
 
   type t = Predicate.t Blang.t
 
-  let compare =
-    (fun a__001_ -> fun b__002_ -> Blang.compare Predicate.compare a__001_ b__002_
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__005_ -> fun b__006_ -> Blang.equal Predicate.equal a__005_ b__006_
      : t -> t -> bool)

--- a/src/dunolint-lib/dunolint/condition.mli
+++ b/src/dunolint-lib/dunolint/condition.mli
@@ -22,6 +22,5 @@
 type t = Predicate.t Blang.t
 
 val equal : t -> t -> bool
-val compare : t -> t -> int
 
 include Sexpable.S with type t := t

--- a/src/dunolint-lib/dunolint/config.ml
+++ b/src/dunolint-lib/dunolint/config.ml
@@ -27,17 +27,6 @@ module T = struct
 
   type t = [ `v1 of V1.t ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `v1 _left__005_, `v1 _right__006_ -> V1.compare _left__005_ _right__006_)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__007_ ->
        fun b__008_ ->

--- a/src/dunolint-lib/dunolint/config.mli
+++ b/src/dunolint-lib/dunolint/config.mli
@@ -22,7 +22,6 @@
 type t
 
 val equal : t -> t -> bool
-val compare : t -> t -> int
 
 (** This is used by tests for quick debug. To print the config into a file, see
     {!val:to_file_contents}. *)

--- a/src/dunolint-lib/dunolint/config_v1.ml
+++ b/src/dunolint-lib/dunolint/config_v1.ml
@@ -26,13 +26,6 @@ module Rule = struct
 
   type t = (Predicate.t, Condition.t) Rule.Stable.V1.t
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       Rule.Stable.V1.compare Predicate.compare Condition.compare a__001_ b__002_
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__007_ ->
        fun b__008_ -> Rule.Stable.V1.equal Predicate.equal Condition.equal a__007_ b__008_
@@ -61,20 +54,6 @@ module Stanza = struct
     [ `skip_paths of Glob.t list
     | `rule of Rule.t
     ]
-
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `skip_paths _left__003_, `skip_paths _right__004_ ->
-           compare_list Glob.compare _left__003_ _right__004_
-         | `rule _left__007_, `rule _right__008_ -> Rule.compare _left__007_ _right__008_
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
 
   let equal =
     (fun a__009_ ->
@@ -143,15 +122,6 @@ module T0 = struct
   [@@@coverage off]
 
   type t = { stanzas : Stanza.t list }
-
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else compare_list Stanza.compare a__001_.stanzas b__002_.stanzas
-     : t -> t -> int)
-  ;;
 
   let equal =
     (fun a__005_ ->

--- a/src/dunolint-lib/dunolint/config_v1.mli
+++ b/src/dunolint-lib/dunolint/config_v1.mli
@@ -22,7 +22,6 @@
 type t
 
 val equal : t -> t -> bool
-val compare : t -> t -> int
 val sexp_of_t : t -> Sexp.t
 val of_stanzas : Sexp.t list -> t
 val to_stanzas : t -> Sexp.t list
@@ -33,7 +32,6 @@ module Rule : sig
   type t = (Predicate.t, Condition.t) Rule.t
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/executable.ml
+++ b/src/dunolint-lib/dunolint/dune0/executable.ml
@@ -36,38 +36,6 @@ module Predicate = struct
     | `public_name of Public_name.Predicate.t Blang.t
     ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `has_field _left__003_, `has_field _right__004_ ->
-           if Stdlib.( == ) _left__003_ _right__004_
-           then 0
-           else (
-             match _left__003_, _right__004_ with
-             | `instrumentation, `instrumentation -> 0
-             | `lint, `lint -> 0
-             | `name, `name -> 0
-             | `preprocess, `preprocess -> 0
-             | `public_name, `public_name -> 0
-             | x, y -> Stdlib.compare x y)
-         | `instrumentation _left__005_, `instrumentation _right__006_ ->
-           Blang.compare Instrumentation.Predicate.compare _left__005_ _right__006_
-         | `lint _left__009_, `lint _right__010_ ->
-           Blang.compare Lint.Predicate.compare _left__009_ _right__010_
-         | `name _left__013_, `name _right__014_ ->
-           Blang.compare Name.Predicate.compare _left__013_ _right__014_
-         | `preprocess _left__017_, `preprocess _right__018_ ->
-           Blang.compare Preprocess.Predicate.compare _left__017_ _right__018_
-         | `public_name _left__021_, `public_name _right__022_ ->
-           Blang.compare Public_name.Predicate.compare _left__021_ _right__022_
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__025_ ->
        fun b__026_ ->

--- a/src/dunolint-lib/dunolint/dune0/executable.mli
+++ b/src/dunolint-lib/dunolint/dune0/executable.mli
@@ -33,7 +33,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/executable__name.ml
+++ b/src/dunolint-lib/dunolint/dune0/executable__name.ml
@@ -38,7 +38,6 @@ module Predicate = struct
 
   type name = t
 
-  let compare_name = (compare : name -> name -> int)
   let equal_name = (equal : name -> name -> bool)
   let name_of_sexp = (t_of_sexp : Sexplib0.Sexp.t -> name)
   let sexp_of_name = (sexp_of_t : name -> Sexplib0.Sexp.t)
@@ -49,23 +48,6 @@ module Predicate = struct
     | `is_prefix of string
     | `is_suffix of string
     ]
-
-  let compare =
-    (fun a__006_ ->
-       fun b__007_ ->
-       if Stdlib.( == ) a__006_ b__007_
-       then 0
-       else (
-         match a__006_, b__007_ with
-         | `equals _left__008_, `equals _right__009_ ->
-           compare_name _left__008_ _right__009_
-         | `is_prefix _left__010_, `is_prefix _right__011_ ->
-           compare_string _left__010_ _right__011_
-         | `is_suffix _left__012_, `is_suffix _right__013_ ->
-           compare_string _left__012_ _right__013_
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
 
   let equal =
     (fun a__014_ ->

--- a/src/dunolint-lib/dunolint/dune0/executable__name.mli
+++ b/src/dunolint-lib/dunolint/dune0/executable__name.mli
@@ -34,7 +34,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/executable__public_name.ml
+++ b/src/dunolint-lib/dunolint/dune0/executable__public_name.ml
@@ -38,7 +38,6 @@ module Predicate = struct
 
   type name = t
 
-  let compare_name = (compare : name -> name -> int)
   let equal_name = (equal : name -> name -> bool)
   let name_of_sexp = (t_of_sexp : Sexplib0.Sexp.t -> name)
   let sexp_of_name = (sexp_of_t : name -> Sexplib0.Sexp.t)
@@ -49,23 +48,6 @@ module Predicate = struct
     | `is_prefix of string
     | `is_suffix of string
     ]
-
-  let compare =
-    (fun a__006_ ->
-       fun b__007_ ->
-       if Stdlib.( == ) a__006_ b__007_
-       then 0
-       else (
-         match a__006_, b__007_ with
-         | `equals _left__008_, `equals _right__009_ ->
-           compare_name _left__008_ _right__009_
-         | `is_prefix _left__010_, `is_prefix _right__011_ ->
-           compare_string _left__010_ _right__011_
-         | `is_suffix _left__012_, `is_suffix _right__013_ ->
-           compare_string _left__012_ _right__013_
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
 
   let equal =
     (fun a__014_ ->

--- a/src/dunolint-lib/dunolint/dune0/executable__public_name.mli
+++ b/src/dunolint-lib/dunolint/dune0/executable__public_name.mli
@@ -34,7 +34,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/include_subdirs.ml
+++ b/src/dunolint-lib/dunolint/dune0/include_subdirs.ml
@@ -30,20 +30,6 @@ module Mode = struct
     | `qualified
     ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `no, `no -> 0
-         | `unqualified, `unqualified -> 0
-         | `qualified, `qualified -> 0
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__003_ ->
        fun b__004_ ->
@@ -102,18 +88,6 @@ module Predicate = struct
   let error_source = "include_subdirs.t"
 
   type t = [ `equals of Mode.t ]
-
-  let compare =
-    (fun a__013_ ->
-       fun b__014_ ->
-       if Stdlib.( == ) a__013_ b__014_
-       then 0
-       else (
-         match a__013_, b__014_ with
-         | `equals _left__015_, `equals _right__016_ ->
-           Mode.compare _left__015_ _right__016_)
-     : t -> t -> int)
-  ;;
 
   let equal =
     (fun a__017_ ->

--- a/src/dunolint-lib/dunolint/dune0/include_subdirs.mli
+++ b/src/dunolint-lib/dunolint/dune0/include_subdirs.mli
@@ -27,7 +27,6 @@ module Mode : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end
@@ -36,7 +35,6 @@ module Predicate : sig
   type t = [ `equals of Mode.t ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/instrumentation.ml
+++ b/src/dunolint-lib/dunolint/dune0/instrumentation.ml
@@ -45,18 +45,6 @@ module Predicate = struct
 
   type t = [ `backend of Backend.Name.t ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `backend _left__003_, `backend _right__004_ ->
-           Backend.Name.compare _left__003_ _right__004_)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__005_ ->
        fun b__006_ ->

--- a/src/dunolint-lib/dunolint/dune0/instrumentation.mli
+++ b/src/dunolint-lib/dunolint/dune0/instrumentation.mli
@@ -32,7 +32,6 @@ module Predicate : sig
   type t = [ `backend of Backend.Name.t ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/library.ml
+++ b/src/dunolint-lib/dunolint/dune0/library.ml
@@ -39,41 +39,6 @@ module Predicate = struct
     | `public_name of Public_name.Predicate.t Blang.t
     ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `has_field _left__003_, `has_field _right__004_ ->
-           if Stdlib.( == ) _left__003_ _right__004_
-           then 0
-           else (
-             match _left__003_, _right__004_ with
-             | `instrumentation, `instrumentation -> 0
-             | `lint, `lint -> 0
-             | `modes, `modes -> 0
-             | `name, `name -> 0
-             | `preprocess, `preprocess -> 0
-             | `public_name, `public_name -> 0
-             | x, y -> Stdlib.compare x y)
-         | `instrumentation _left__005_, `instrumentation _right__006_ ->
-           Blang.compare Instrumentation.Predicate.compare _left__005_ _right__006_
-         | `lint _left__009_, `lint _right__010_ ->
-           Blang.compare Lint.Predicate.compare _left__009_ _right__010_
-         | `modes _left__013_, `modes _right__014_ ->
-           Blang.compare Modes.Predicate.compare _left__013_ _right__014_
-         | `name _left__017_, `name _right__018_ ->
-           Blang.compare Name.Predicate.compare _left__017_ _right__018_
-         | `preprocess _left__021_, `preprocess _right__022_ ->
-           Blang.compare Preprocess.Predicate.compare _left__021_ _right__022_
-         | `public_name _left__025_, `public_name _right__026_ ->
-           Blang.compare Public_name.Predicate.compare _left__025_ _right__026_
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__029_ ->
        fun b__030_ ->

--- a/src/dunolint-lib/dunolint/dune0/library.mli
+++ b/src/dunolint-lib/dunolint/dune0/library.mli
@@ -36,7 +36,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/library__modes.ml
+++ b/src/dunolint-lib/dunolint/dune0/library__modes.ml
@@ -31,21 +31,6 @@ module Predicate = struct
     | `has_modes of Compilation_mode.t list
     ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `has_mode _left__003_, `has_mode _right__004_ ->
-           Compilation_mode.compare _left__003_ _right__004_
-         | `has_modes _left__005_, `has_modes _right__006_ ->
-           compare_list Compilation_mode.compare _left__005_ _right__006_
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__009_ ->
        fun b__010_ ->

--- a/src/dunolint-lib/dunolint/dune0/library__modes.mli
+++ b/src/dunolint-lib/dunolint/dune0/library__modes.mli
@@ -48,7 +48,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/library__name.ml
+++ b/src/dunolint-lib/dunolint/dune0/library__name.ml
@@ -38,7 +38,6 @@ module Predicate = struct
 
   type name = t
 
-  let compare_name = (compare : name -> name -> int)
   let equal_name = (equal : name -> name -> bool)
   let name_of_sexp = (t_of_sexp : Sexplib0.Sexp.t -> name)
   let sexp_of_name = (sexp_of_t : name -> Sexplib0.Sexp.t)
@@ -49,23 +48,6 @@ module Predicate = struct
     | `is_prefix of string
     | `is_suffix of string
     ]
-
-  let compare =
-    (fun a__006_ ->
-       fun b__007_ ->
-       if Stdlib.( == ) a__006_ b__007_
-       then 0
-       else (
-         match a__006_, b__007_ with
-         | `equals _left__008_, `equals _right__009_ ->
-           compare_name _left__008_ _right__009_
-         | `is_prefix _left__010_, `is_prefix _right__011_ ->
-           compare_string _left__010_ _right__011_
-         | `is_suffix _left__012_, `is_suffix _right__013_ ->
-           compare_string _left__012_ _right__013_
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
 
   let equal =
     (fun a__014_ ->

--- a/src/dunolint-lib/dunolint/dune0/library__name.mli
+++ b/src/dunolint-lib/dunolint/dune0/library__name.mli
@@ -34,7 +34,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/library__public_name.ml
+++ b/src/dunolint-lib/dunolint/dune0/library__public_name.ml
@@ -38,7 +38,6 @@ module Predicate = struct
 
   type name = t
 
-  let compare_name = (compare : name -> name -> int)
   let equal_name = (equal : name -> name -> bool)
   let name_of_sexp = (t_of_sexp : Sexplib0.Sexp.t -> name)
   let sexp_of_name = (sexp_of_t : name -> Sexplib0.Sexp.t)
@@ -49,23 +48,6 @@ module Predicate = struct
     | `is_prefix of string
     | `is_suffix of string
     ]
-
-  let compare =
-    (fun a__006_ ->
-       fun b__007_ ->
-       if Stdlib.( == ) a__006_ b__007_
-       then 0
-       else (
-         match a__006_, b__007_ with
-         | `equals _left__008_, `equals _right__009_ ->
-           compare_name _left__008_ _right__009_
-         | `is_prefix _left__010_, `is_prefix _right__011_ ->
-           compare_string _left__010_ _right__011_
-         | `is_suffix _left__012_, `is_suffix _right__013_ ->
-           compare_string _left__012_ _right__013_
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
 
   let equal =
     (fun a__014_ ->

--- a/src/dunolint-lib/dunolint/dune0/library__public_name.mli
+++ b/src/dunolint-lib/dunolint/dune0/library__public_name.mli
@@ -34,7 +34,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/lint.ml
+++ b/src/dunolint-lib/dunolint/dune0/lint.ml
@@ -26,18 +26,6 @@ module Predicate = struct
 
   type t = [ `pps of Pps.Predicate.t Blang.t ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `pps _left__003_, `pps _right__004_ ->
-           Blang.compare Pps.Predicate.compare _left__003_ _right__004_)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__007_ ->
        fun b__008_ ->

--- a/src/dunolint-lib/dunolint/dune0/lint.mli
+++ b/src/dunolint-lib/dunolint/dune0/lint.mli
@@ -37,7 +37,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/pps.ml
+++ b/src/dunolint-lib/dunolint/dune0/pps.ml
@@ -34,22 +34,6 @@ module Predicate = struct
       | `equals of string
       ]
 
-    let compare =
-      (fun a__001_ ->
-         fun b__002_ ->
-         if Stdlib.( == ) a__001_ b__002_
-         then 0
-         else (
-           match a__001_, b__002_ with
-           | `any, `any -> 0
-           | `none, `none -> 0
-           | `some, `some -> 0
-           | `equals _left__003_, `equals _right__004_ ->
-             compare_string _left__003_ _right__004_
-           | x, y -> Stdlib.compare x y)
-       : t -> t -> int)
-    ;;
-
     let equal =
       (fun a__005_ ->
          fun b__006_ ->
@@ -128,21 +112,6 @@ module Predicate = struct
         | `pp of Pp.Name.t
         ]
 
-      let compare =
-        (fun a__021_ ->
-           fun b__022_ ->
-           if Stdlib.( == ) a__021_ b__022_
-           then 0
-           else (
-             match a__021_, b__022_ with
-             | `any, `any -> 0
-             | `driver, `driver -> 0
-             | `pp _left__023_, `pp _right__024_ ->
-               Pp.Name.compare _left__023_ _right__024_
-             | x, y -> Stdlib.compare x y)
-         : t -> t -> int)
-      ;;
-
       let equal =
         (fun a__025_ ->
            fun b__026_ ->
@@ -213,21 +182,6 @@ module Predicate = struct
       ; param : Param.t
       ; applies_to : Applies_to.t
       }
-
-    let compare =
-      (fun a__041_ ->
-         fun b__042_ ->
-         if Stdlib.( == ) a__041_ b__042_
-         then 0
-         else (
-           match compare_string a__041_.name b__042_.name with
-           | 0 ->
-             (match Param.compare a__041_.param b__042_.param with
-              | 0 -> Applies_to.compare a__041_.applies_to b__042_.applies_to
-              | n -> n)
-           | n -> n)
-       : t -> t -> int)
-    ;;
 
     let equal =
       (fun a__043_ ->
@@ -311,21 +265,6 @@ module Predicate = struct
       ; param : Param.t
       }
 
-    let compare =
-      (fun a__055_ ->
-         fun b__056_ ->
-         if Stdlib.( == ) a__055_ b__056_
-         then 0
-         else (
-           match Pp.Name.compare a__055_.pp b__056_.pp with
-           | 0 ->
-             (match compare_string a__055_.flag b__056_.flag with
-              | 0 -> Param.compare a__055_.param b__056_.param
-              | n -> n)
-           | n -> n)
-       : t -> t -> int)
-    ;;
-
     let equal =
       (fun a__057_ ->
          fun b__058_ ->
@@ -404,21 +343,6 @@ module Predicate = struct
     | `flag of Flag.t
     | `pp_with_flag of Pp_with_flag.t
     ]
-
-  let compare =
-    (fun a__069_ ->
-       fun b__070_ ->
-       if Stdlib.( == ) a__069_ b__070_
-       then 0
-       else (
-         match a__069_, b__070_ with
-         | `pp _left__071_, `pp _right__072_ -> Pp.Name.compare _left__071_ _right__072_
-         | `flag _left__073_, `flag _right__074_ -> Flag.compare _left__073_ _right__074_
-         | `pp_with_flag _left__075_, `pp_with_flag _right__076_ ->
-           Pp_with_flag.compare _left__075_ _right__076_
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
 
   let equal =
     (fun a__077_ ->

--- a/src/dunolint-lib/dunolint/dune0/pps.mli
+++ b/src/dunolint-lib/dunolint/dune0/pps.mli
@@ -29,7 +29,6 @@ module Predicate : sig
       ]
 
     val equal : t -> t -> bool
-    val compare : t -> t -> int
 
     include Sexpable.S with type t := t
   end
@@ -43,7 +42,6 @@ module Predicate : sig
         ]
 
       val equal : t -> t -> bool
-      val compare : t -> t -> int
 
       include Sexpable.S with type t := t
     end
@@ -55,7 +53,6 @@ module Predicate : sig
       }
 
     val equal : t -> t -> bool
-    val compare : t -> t -> int
 
     include Sexpable.S with type t := t
   end
@@ -68,7 +65,6 @@ module Predicate : sig
       }
 
     val equal : t -> t -> bool
-    val compare : t -> t -> int
 
     include Sexpable.S with type t := t
   end
@@ -80,7 +76,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/predicate.ml
+++ b/src/dunolint-lib/dunolint/dune0/predicate.ml
@@ -34,42 +34,6 @@ type t =
   | `stanza of Stanza.Predicate.t Blang.t
   ]
 
-let compare =
-  (fun a__001_ ->
-     fun b__002_ ->
-     if Stdlib.( == ) a__001_ b__002_
-     then 0
-     else (
-       match a__001_, b__002_ with
-       | `executable _left__003_, `executable _right__004_ ->
-         Blang.compare Executable.Predicate.compare _left__003_ _right__004_
-       | `has_field _left__007_, `has_field _right__008_ ->
-         if Stdlib.( == ) _left__007_ _right__008_
-         then 0
-         else (
-           match _left__007_, _right__008_ with
-           | `instrumentation, `instrumentation -> 0
-           | `lint, `lint -> 0
-           | `name, `name -> 0
-           | `preprocess, `preprocess -> 0
-           | `public_name, `public_name -> 0
-           | x, y -> Stdlib.compare x y)
-       | `include_subdirs _left__009_, `include_subdirs _right__010_ ->
-         Blang.compare Include_subdirs.Predicate.compare _left__009_ _right__010_
-       | `instrumentation _left__013_, `instrumentation _right__014_ ->
-         Blang.compare Instrumentation.Predicate.compare _left__013_ _right__014_
-       | `library _left__017_, `library _right__018_ ->
-         Blang.compare Library.Predicate.compare _left__017_ _right__018_
-       | `lint _left__021_, `lint _right__022_ ->
-         Blang.compare Lint.Predicate.compare _left__021_ _right__022_
-       | `preprocess _left__025_, `preprocess _right__026_ ->
-         Blang.compare Preprocess.Predicate.compare _left__025_ _right__026_
-       | `stanza _left__029_, `stanza _right__030_ ->
-         Blang.compare Stanza.Predicate.compare _left__029_ _right__030_
-       | x, y -> Stdlib.compare x y)
-   : t -> t -> int)
-;;
-
 let equal =
   (fun a__033_ ->
      fun b__034_ ->

--- a/src/dunolint-lib/dunolint/dune0/predicate.mli
+++ b/src/dunolint-lib/dunolint/dune0/predicate.mli
@@ -31,6 +31,5 @@ type t =
   ]
 
 val equal : t -> t -> bool
-val compare : t -> t -> int
 
 include Sexpable.S with type t := t

--- a/src/dunolint-lib/dunolint/dune0/preprocess.ml
+++ b/src/dunolint-lib/dunolint/dune0/preprocess.ml
@@ -29,20 +29,6 @@ module Predicate = struct
     | `pps of Pps.Predicate.t Blang.t
     ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `no_preprocessing, `no_preprocessing -> 0
-         | `pps _left__003_, `pps _right__004_ ->
-           Blang.compare Pps.Predicate.compare _left__003_ _right__004_
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__007_ ->
        fun b__008_ ->

--- a/src/dunolint-lib/dunolint/dune0/preprocess.mli
+++ b/src/dunolint-lib/dunolint/dune0/preprocess.mli
@@ -40,7 +40,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune0/stanza.ml
+++ b/src/dunolint-lib/dunolint/dune0/stanza.ml
@@ -31,21 +31,6 @@ module Predicate = struct
     | `executables
     ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `include_subdirs, `include_subdirs -> 0
-         | `library, `library -> 0
-         | `executable, `executable -> 0
-         | `executables, `executables -> 0
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__003_ ->
        fun b__004_ ->

--- a/src/dunolint-lib/dunolint/dune0/stanza.mli
+++ b/src/dunolint-lib/dunolint/dune0/stanza.mli
@@ -28,7 +28,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune_project0/dune_lang_version.ml
+++ b/src/dunolint-lib/dunolint/dune_project0/dune_lang_version.ml
@@ -78,7 +78,6 @@ module Predicate = struct
   (* Given the actual shape and representation of the values inhabiting this
      type, polymorphic comparison is adequate here. *)
 
-  let compare : t -> t -> int = Stdlib.compare
   let equal : t -> t -> bool = Stdlib.( = )
 
   module Opv = struct

--- a/src/dunolint-lib/dunolint/dune_project0/dune_lang_version.mli
+++ b/src/dunolint-lib/dunolint/dune_project0/dune_lang_version.mli
@@ -65,7 +65,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune_project0/generate_opam_files.ml
+++ b/src/dunolint-lib/dunolint/dune_project0/generate_opam_files.ml
@@ -26,17 +26,6 @@ module Predicate = struct
 
   type t = [ `is_present ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `is_present, `is_present -> 0)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__003_ ->
        fun b__004_ ->

--- a/src/dunolint-lib/dunolint/dune_project0/generate_opam_files.mli
+++ b/src/dunolint-lib/dunolint/dune_project0/generate_opam_files.mli
@@ -23,7 +23,6 @@ module Predicate : sig
   type t = [ `is_present ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune_project0/implicit_transitive_deps.ml
+++ b/src/dunolint-lib/dunolint/dune_project0/implicit_transitive_deps.ml
@@ -28,18 +28,6 @@ module Predicate = struct
 
   type t = [ `equals of Value.t ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `equals _left__003_, `equals _right__004_ ->
-           Value.compare _left__003_ _right__004_)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__005_ ->
        fun b__006_ ->

--- a/src/dunolint-lib/dunolint/dune_project0/implicit_transitive_deps.mli
+++ b/src/dunolint-lib/dunolint/dune_project0/implicit_transitive_deps.mli
@@ -25,7 +25,6 @@ module Predicate : sig
   type t = [ `equals of Value.t ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune_project0/name.ml
+++ b/src/dunolint-lib/dunolint/dune_project0/name.ml
@@ -40,7 +40,6 @@ module Predicate = struct
 
   type name = t
 
-  let compare_name = (compare : name -> name -> int)
   let equal_name = (equal : name -> name -> bool)
   let name_of_sexp = (t_of_sexp : Sexplib0.Sexp.t -> name)
   let sexp_of_name = (sexp_of_t : name -> Sexplib0.Sexp.t)
@@ -50,23 +49,6 @@ module Predicate = struct
     | `is_prefix of string
     | `is_suffix of string
     ]
-
-  let compare =
-    (fun a__006_ ->
-       fun b__007_ ->
-       if Stdlib.( == ) a__006_ b__007_
-       then 0
-       else (
-         match a__006_, b__007_ with
-         | `equals _left__008_, `equals _right__009_ ->
-           compare_name _left__008_ _right__009_
-         | `is_prefix _left__010_, `is_prefix _right__011_ ->
-           compare_string _left__010_ _right__011_
-         | `is_suffix _left__012_, `is_suffix _right__013_ ->
-           compare_string _left__012_ _right__013_
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
 
   let equal =
     (fun a__014_ ->

--- a/src/dunolint-lib/dunolint/dune_project0/name.mli
+++ b/src/dunolint-lib/dunolint/dune_project0/name.mli
@@ -34,7 +34,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dune_project0/predicate.ml
+++ b/src/dunolint-lib/dunolint/dune_project0/predicate.ml
@@ -30,25 +30,6 @@ type t =
   | `name of Name.Predicate.t Blang.t
   ]
 
-let compare =
-  (fun a__001_ ->
-     fun b__002_ ->
-     if Stdlib.( == ) a__001_ b__002_
-     then 0
-     else (
-       match a__001_, b__002_ with
-       | `dune_lang_version _left__003_, `dune_lang_version _right__004_ ->
-         Blang.compare Dune_lang_version.Predicate.compare _left__003_ _right__004_
-       | `generate_opam_files _left__007_, `generate_opam_files _right__008_ ->
-         Blang.compare Generate_opam_files.Predicate.compare _left__007_ _right__008_
-       | `implicit_transitive_deps _left__011_, `implicit_transitive_deps _right__012_ ->
-         Blang.compare Implicit_transitive_deps.Predicate.compare _left__011_ _right__012_
-       | `name _left__015_, `name _right__016_ ->
-         Blang.compare Name.Predicate.compare _left__015_ _right__016_
-       | x, y -> Stdlib.compare x y)
-   : t -> t -> int)
-;;
-
 let equal =
   (fun a__019_ ->
      fun b__020_ ->

--- a/src/dunolint-lib/dunolint/dune_project0/predicate.mli
+++ b/src/dunolint-lib/dunolint/dune_project0/predicate.mli
@@ -26,7 +26,6 @@ type t =
   | `name of Name.Predicate.t Blang.t
   ]
 
-val compare : t -> t -> int
 val equal : t -> t -> bool
 val sexp_of_t : t -> Sexplib0.Sexp.t
 val t_of_sexp : Sexplib0.Sexp.t -> t

--- a/src/dunolint-lib/dunolint/dunolint1/dunolint_lang_version.ml
+++ b/src/dunolint-lib/dunolint/dunolint1/dunolint_lang_version.ml
@@ -89,7 +89,6 @@ module Predicate = struct
   (* Given the actual shape and representation of the values inhabiting this
      type, polymorphic comparison is adequate here. *)
 
-  let compare : t -> t -> int = Stdlib.compare
   let equal : t -> t -> bool = Stdlib.( = )
 
   module Opv = struct

--- a/src/dunolint-lib/dunolint/dunolint1/dunolint_lang_version.mli
+++ b/src/dunolint-lib/dunolint/dunolint1/dunolint_lang_version.mli
@@ -55,7 +55,6 @@ module Predicate : sig
     ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/dunolint1/predicate.ml
+++ b/src/dunolint-lib/dunolint/dunolint1/predicate.ml
@@ -23,16 +23,14 @@ let error_source = "predicate.t"
 
 type t = [ `dunolint_lang_version of Dunolint_lang_version.Predicate.t Blang.t ]
 
-let compare (a : t) (b : t) =
+let equal (a : t) (b : t) =
   if Stdlib.( == ) a b
-  then 0
+  then true
   else (
     match a, b with
     | `dunolint_lang_version va, `dunolint_lang_version vb ->
-      Blang.compare Dunolint_lang_version.Predicate.compare va vb)
+      Blang.equal Dunolint_lang_version.Predicate.equal va vb)
 ;;
-
-let equal a b = 0 = compare a b
 
 let predicates : t Sexp_helpers.Predicate_spec.t =
   [ { atom = "dunolint_lang_version"

--- a/src/dunolint-lib/dunolint/dunolint1/predicate.mli
+++ b/src/dunolint-lib/dunolint/dunolint1/predicate.mli
@@ -21,7 +21,6 @@
 
 type t = [ `dunolint_lang_version of Dunolint_lang_version.Predicate.t Blang.t ]
 
-val compare : t -> t -> int
 val equal : t -> t -> bool
 val sexp_of_t : t -> Sexplib0.Sexp.t
 val t_of_sexp : Sexplib0.Sexp.t -> t

--- a/src/dunolint-lib/dunolint/path.ml
+++ b/src/dunolint-lib/dunolint/path.ml
@@ -28,17 +28,6 @@ module Predicate = struct
 
   type t = [ `glob of Glob.t ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `glob _left__005_, `glob _right__006_ -> Glob.compare _left__005_ _right__006_)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__007_ ->
        fun b__008_ ->

--- a/src/dunolint-lib/dunolint/path.mli
+++ b/src/dunolint-lib/dunolint/path.mli
@@ -23,7 +23,6 @@ module Predicate : sig
   type t = [ `glob of Glob.t ]
 
   val equal : t -> t -> bool
-  val compare : t -> t -> int
 
   include Sexpable.S with type t := t
 end

--- a/src/dunolint-lib/dunolint/predicate.ml
+++ b/src/dunolint-lib/dunolint/predicate.ml
@@ -31,25 +31,6 @@ module T = struct
     | `dunolint of Dunolint0.Predicate.t Blang.t
     ]
 
-  let compare =
-    (fun a__001_ ->
-       fun b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
-       then 0
-       else (
-         match a__001_, b__002_ with
-         | `path _left__003_, `path _right__004_ ->
-           Blang.compare Path.Predicate.compare _left__003_ _right__004_
-         | `dune _left__007_, `dune _right__008_ ->
-           Blang.compare Dune.Predicate.compare _left__007_ _right__008_
-         | `dune_project _left__011_, `dune_project _right__012_ ->
-           Blang.compare Dune_project.Predicate.compare _left__011_ _right__012_
-         | `dunolint _left__013_, `dunolint _right__014_ ->
-           Blang.compare Dunolint0.Predicate.compare _left__013_ _right__014_
-         | x, y -> Stdlib.compare x y)
-     : t -> t -> int)
-  ;;
-
   let equal =
     (fun a__015_ ->
        fun b__016_ ->

--- a/src/dunolint-lib/dunolint/predicate.mli
+++ b/src/dunolint-lib/dunolint/predicate.mli
@@ -27,6 +27,5 @@ type t =
   ]
 
 val equal : t -> t -> bool
-val compare : t -> t -> int
 
 include Sexpable.S with type t := t

--- a/src/dunolint-lib/dunolint/rule.ml
+++ b/src/dunolint-lib/dunolint/rule.ml
@@ -30,39 +30,6 @@ module T = struct
     | `cond of ('predicate Blang.t * ('predicate, 'invariant) t) list
     ]
 
-  let rec compare
-    :  'predicate 'invariant.
-       ('predicate -> 'predicate -> int)
-    -> ('invariant -> 'invariant -> int)
-    -> ('predicate, 'invariant) t
-    -> ('predicate, 'invariant) t
-    -> int
-    =
-    fun _cmp__predicate ->
-    fun _cmp__invariant ->
-    fun a__001_ ->
-    fun b__002_ ->
-    if Stdlib.( == ) a__001_ b__002_
-    then 0
-    else (
-      match a__001_, b__002_ with
-      | `enforce _left__003_, `enforce _right__004_ ->
-        _cmp__invariant _left__003_ _right__004_
-      | `return, `return -> 0
-      | `cond _left__005_, `cond _right__006_ ->
-        compare_list
-          (fun a__007_ ->
-             fun b__008_ ->
-             let t__009_, t__010_ = a__007_ in
-             let t__011_, t__012_ = b__008_ in
-             match Blang.compare _cmp__predicate t__009_ t__011_ with
-             | 0 -> compare _cmp__predicate _cmp__invariant t__010_ t__012_
-             | n -> n)
-          _left__005_
-          _right__006_
-      | x, y -> Stdlib.compare x y)
-  ;;
-
   let rec equal
     :  'predicate 'invariant.
        ('predicate -> 'predicate -> bool)
@@ -221,7 +188,6 @@ module Stable = struct
                Sexplib0.Sexp.List [ res0__100_; res1__101_ ]))
     ;;
 
-    let compare = compare
     let equal = equal
   end
 end

--- a/src/dunolint-lib/dunolint/rule.mli
+++ b/src/dunolint-lib/dunolint/rule.mli
@@ -27,7 +27,6 @@ type ('predicate, 'invariant) t =
   | `cond of ('predicate Blang.t * ('predicate, 'invariant) t) list
   ]
 
-val compare : ('p -> 'p -> int) -> ('i -> 'i -> int) -> ('p, 'i) t -> ('p, 'i) t -> int
 val equal : ('p -> 'p -> bool) -> ('i -> 'i -> bool) -> ('p, 'i) t -> ('p, 'i) t -> bool
 
 val eval
@@ -38,13 +37,6 @@ val eval
 module Stable : sig
   module V1 : sig
     type nonrec ('a, 'b) t = ('a, 'b) t
-
-    val compare
-      :  ('p -> 'p -> int)
-      -> ('i -> 'i -> int)
-      -> ('p, 'i) t
-      -> ('p, 'i) t
-      -> int
 
     val equal
       :  ('p -> 'p -> bool)

--- a/test/dunolint-lib/common.ml
+++ b/test/dunolint-lib/common.ml
@@ -20,7 +20,7 @@
 (*********************************************************************************)
 
 module type Roundtripable = sig
-  type t [@@deriving compare, equal, sexp]
+  type t [@@deriving equal, sexp]
 end
 
 let test_roundtrip (type a) (module M : Roundtripable with type t = a) (a : a) =
@@ -32,12 +32,12 @@ let test_roundtrip (type a) (module M : Roundtripable with type t = a) (a : a) =
 ;;
 
 module type Predicate = sig
-  type t [@@deriving compare, equal, sexp]
+  type t [@@deriving equal, sexp]
 end
 
 let test_predicate (type a) (module M : Predicate with type t = a) predicate =
   let module B = struct
-    type t = M.t Blang.t [@@deriving compare, equal, sexp]
+    type t = M.t Blang.t [@@deriving equal, sexp]
   end
   in
   test_roundtrip (module B) predicate;

--- a/test/dunolint-lib/common.mli
+++ b/test/dunolint-lib/common.mli
@@ -20,13 +20,13 @@
 (*_********************************************************************************)
 
 module type Roundtripable = sig
-  type t [@@deriving compare, equal, sexp]
+  type t [@@deriving equal, sexp]
 end
 
 val test_roundtrip : (module Roundtripable with type t = 'a) -> 'a -> unit
 
 module type Predicate = sig
-  type t [@@deriving compare, equal, sexp]
+  type t [@@deriving equal, sexp]
 end
 
 val test_predicate : (module Predicate with type t = 'a) -> 'a Blang.t -> unit

--- a/test/dunolint-lib/test__config.ml
+++ b/test/dunolint-lib/test__config.ml
@@ -70,7 +70,9 @@ let%expect_test "non-empty-v1" =
   [%expect {||}];
   let rules = Dunolint.Config.V1.rules v1 in
   let t' = Dunolint.Config.create ~rules () in
-  require_equal [%here] (module Int) 1 (Dunolint.Config.compare t t');
+  (* t and t' are different because t includes skip_paths. *)
+  print_s [%sexp (Dunolint.Config.equal t t' : bool)];
+  [%expect {| false |}];
   ()
 ;;
 

--- a/test/dunolint-lib/test__dunolint0__predicate.ml
+++ b/test/dunolint-lib/test__dunolint0__predicate.ml
@@ -36,23 +36,3 @@ let%expect_test "equal" =
   [%expect {| false |}];
   ()
 ;;
-
-let%expect_test "compare" =
-  let v1_0 = Dunolint0.Dunolint_lang_version.create (1, 0) in
-  let v1_5 = Dunolint0.Dunolint_lang_version.create (1, 5) in
-  let p1 : Dunolint0.Predicate.t = `dunolint_lang_version (Blang.base (`gte v1_0)) in
-  let p2 : Dunolint0.Predicate.t = `dunolint_lang_version (Blang.base (`gte v1_0)) in
-  let p3 : Dunolint0.Predicate.t = `dunolint_lang_version (Blang.base (`gte v1_5)) in
-  (* Same value, different references. *)
-  print_s [%sexp (Dunolint0.Predicate.compare p1 p2 : int)];
-  [%expect {| 0 |}];
-  (* Physical equality. *)
-  print_s [%sexp (Dunolint0.Predicate.compare p1 p1 : int)];
-  [%expect {| 0 |}];
-  (* Different values - p1 < p3 because v1_0 < v1_5. *)
-  print_s [%sexp (Dunolint0.Predicate.compare p1 p3 < 0 : bool)];
-  [%expect {| true |}];
-  print_s [%sexp (Dunolint0.Predicate.compare p3 p1 > 0 : bool)];
-  [%expect {| true |}];
-  ()
-;;

--- a/test/dunolint-lib/test__rule.ml
+++ b/test/dunolint-lib/test__rule.ml
@@ -27,7 +27,7 @@ module Trilang = struct
       | True
       | False
       | Undefined
-    [@@deriving compare, sexp]
+    [@@deriving equal, sexp]
   end
 
   include T0
@@ -50,9 +50,9 @@ module Trilang = struct
 end
 
 module T = struct
-  type t = (Trilang.t, int) Dunolint.Rule.Stable.V1.t [@@deriving compare, sexp]
+  type t = (Trilang.t, int) Dunolint.Rule.Stable.V1.t [@@deriving sexp]
 
-  let equal t1 t2 = 0 = compare t1 t2
+  let equal t1 t2 = Dunolint.Rule.Stable.V1.equal Trilang.equal Int.equal t1 t2
 end
 
 let%expect_test "sexp" =


### PR DESCRIPTION
The compare operations on Predicates were not being used. With no actual use case, we're removing them to simplify the codebase. We're keeping equal.