### PR TITLE
Make a few dunolint config parsing errors more user-friendly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 
 ### Changed
 
+- Make a few dunolint config parsing errors more friendly (#155, @mbarbin).
 - Refactor sexp parsing - prerequisite for future improvements (#152, @mbarbin).
 - Cleanup implementation of `equal` functions (#151, @mbarbin).
 - Extend lang version compare operators (#145, @mbarbin).

--- a/src/dunolint-lib/dunolint/sexp_helpers.mli
+++ b/src/dunolint-lib/dunolint/sexp_helpers.mli
@@ -38,6 +38,42 @@ module type T_of_sexp = sig
   val t_of_sexp : Sexp.t -> t
 end
 
+(** {1 Error handling} *)
+
+module Error_context : sig
+  (** Embed context to make parsing errors more user-friendly.
+
+      We're using a custom exception that allows embedding special context whose
+      purpose is to improve the parsing errors that dunolint prints to the
+      users.
+
+      For example, when we fail to find a match for a particular construct or
+      keyword looked up by name, we give the list of known ones so as to allow
+      messages like: "Did you mean X?".
+
+      The way we integrate this with the raising mecanism of [Sexplib0] is to
+      embed the context into the exception type defined below, and have such
+      exception be the first argument to the [Of_sexp_error (e, _)] error. *)
+
+  type t
+
+  exception E of t
+
+  val message : t -> string
+
+  module Did_you_mean : sig
+    type t =
+      { var : string
+      ; candidates : string list
+      }
+  end
+
+  val did_you_mean : t -> Did_you_mean.t option
+  val suggestion : t -> string option
+end
+
+(** {1 Parsing utils} *)
+
 (** When a record is embedded by a variant or polymorphic variant we'd like to
     support a syntax with less parens around. For example:
 

--- a/src/dunolint/dunolinter/config_handler.ml
+++ b/src/dunolint/dunolinter/config_handler.ml
@@ -45,11 +45,5 @@ let load_config_exn ~filename =
          | Some range -> Sexp_handler.loc_of_parsexp_range ~filename range
          | None -> Loc.of_file ~path:(Fpath.v filename) [@coverage off]
        in
-       let message =
-         match exn with
-         | Failure str ->
-           Pp.text (if String.is_suffix str ~suffix:"." then str else str ^ ".")
-         | exn -> Err.exn exn [@coverage off]
-       in
-       Err.raise ~loc [ message ])
+       raise (Err.E (Sexp_handler.render_sexp_error_exn ~loc exn)))
 ;;

--- a/src/dunolint/dunolinter/sexp_handler.mli
+++ b/src/dunolint/dunolinter/sexp_handler.mli
@@ -131,3 +131,7 @@ val read
 
 (** Shared utils to map a Parsexp range to a Loc.t. *)
 val loc_of_parsexp_range : filename:string -> Parsexp.Positions.range -> Loc.t
+
+(** Special logic to render an exception located in a [Of_sexp_error]
+    constructor, with special logic to embed user friendly context. *)
+val render_sexp_error_exn : loc:Loc.t -> exn -> Err.t

--- a/test/cram/load-config-errors.t
+++ b/test/cram/load-config-errors.t
@@ -162,33 +162,35 @@ Unknown constructor.
   File "dunolint", line 3, characters 15-60:
   3 | (rule (enforce (duno (instrumentation (backend bisect_ppx)))))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: predicate.t_of_sexp: no matching variant found.
+  Error: Unknown construct [duno].
+  Hint: did you mean dune?
   [123]
 
   $ cat > dunolint <<EOF
   > (lang dunolint 1.0)
   > 
-  > (rule (enforce (dune (library (modes (has_modes modo))))))
+  > (rule (enforce (dune (library (modes (has_modes native))))))
   > EOF
 
   $ dunolint tools config validate dunolint
-  File "dunolint", line 3, characters 48-52:
-  3 | (rule (enforce (dune (library (modes (has_modes modo))))))
-                                                      ^^^^
+  File "dunolint", line 3, characters 48-54:
+  3 | (rule (enforce (dune (library (modes (has_modes native))))))
+                                                      ^^^^^^
   Error: list_of_sexp: list needed.
   [123]
 
   $ cat > dunolint <<EOF
   > (lang dunolint 1.0)
   > 
-  > (rule (enforce (dune (library (modes (has_mode modo))))))
+  > (rule (enforce (dune (library (modes (has_mode mative))))))
   > EOF
 
   $ dunolint tools config validate dunolint
-  File "dunolint", line 3, characters 47-51:
-  3 | (rule (enforce (dune (library (modes (has_mode modo))))))
-                                                     ^^^^
-  Error: compilation_mode.t_of_sexp: no matching variant found.
+  File "dunolint", line 3, characters 47-53:
+  3 | (rule (enforce (dune (library (modes (has_mode mative))))))
+                                                     ^^^^^^
+  Error: Unknown construct [mative].
+  Hint: did you mean native?
   [123]
 
 There was a short period of time where dune lang versions were allowed to be
@@ -265,3 +267,18 @@ Located errors for invalid stanzas, or stanzas with invalid args.
   Error: config.v1.stanza.t_of_sexp: polymorphic variant tag takes an argument.
   [123]
 
+Missing argument.
+
+  $ cat > dunolint <<EOF
+  > (lang dunolint 1.0)
+  > 
+  > (rule (enforce (dune (instrumentation backend))))
+  > EOF
+
+  $ dunolint tools config validate dunolint
+  File "dunolint", line 3, characters 38-45:
+  3 | (rule (enforce (dune (instrumentation backend))))
+                                            ^^^^^^^
+  Error: The construct [backend] expects one or more arguments.
+  Hint: Replace by: (backend ARG)
+  [123]

--- a/test/cram/unsupported-constructs.t
+++ b/test/cram/unsupported-constructs.t
@@ -19,7 +19,7 @@ Create build files.
   $ cat > lib/foo/dune <<EOF
   > (library
   >  (name bar)
-  >  (modes unknown))
+  >  (modes bytes))
   > EOF
 
   $ dunolint lint
@@ -28,8 +28,9 @@ Create build files.
                                 ^^^^^^^
   Error: Unsupported implicit_transitive_deps value [unknown].
   
-  File "lib/foo/dune", line 3, characters 8-15:
-  3 |  (modes unknown))
-              ^^^^^^^
-  Error: compilation_mode.t_of_sexp: no matching variant found.
+  File "lib/foo/dune", line 3, characters 8-13:
+  3 |  (modes bytes))
+              ^^^^^
+  Error: Unknown construct [bytes].
+  Hint: did you mean byte?
   [123]

--- a/test/dunolint-lib/test__dune_project__dune_lang_version.ml
+++ b/test/dunolint-lib/test__dune_project__dune_lang_version.ml
@@ -171,7 +171,9 @@ let%expect_test "Predicate.t_of_sexp" =
   [%expect
     {|
     (Of_sexp_error
-     "dune_lang_version.t_of_sexp: polymorphic variant tag takes an argument"
+     (Dunolint.Sexp_helpers.Error_context.E
+      ("The construct [=] expects one or more arguments."
+       (suggestion "Replace by: (= ARG)")))
      (invalid_sexp =))
     |}];
   test "(= 3.20 extra)";
@@ -184,7 +186,13 @@ let%expect_test "Predicate.t_of_sexp" =
   test "(unknown 3.20)";
   [%expect
     {|
-    (Of_sexp_error "dune_lang_version.t_of_sexp: no matching variant found"
+    (Of_sexp_error
+     (Dunolint.Sexp_helpers.Error_context.E
+      ("Unknown construct [unknown]."
+       (did_you_mean?
+        ((var unknown)
+         (candidates = > >= < <= != equals greater_than_or_equal_to
+          less_than_or_equal_to)))))
      (invalid_sexp (unknown 3.20)))
     |}];
   ()

--- a/test/dunolint-lib/test__dune_workspace__dune_lang_version.ml
+++ b/test/dunolint-lib/test__dune_workspace__dune_lang_version.ml
@@ -143,7 +143,9 @@ let%expect_test "Predicate.t_of_sexp" =
   [%expect
     {|
     (Of_sexp_error
-     "dune_lang_version.t_of_sexp: polymorphic variant tag takes an argument"
+     (Dunolint.Sexp_helpers.Error_context.E
+      ("The construct [=] expects one or more arguments."
+       (suggestion "Replace by: (= ARG)")))
      (invalid_sexp =))
     |}];
   test "(= 3.17 extra)";
@@ -156,7 +158,10 @@ let%expect_test "Predicate.t_of_sexp" =
   test "(unknown 3.17)";
   [%expect
     {|
-    (Of_sexp_error "dune_lang_version.t_of_sexp: no matching variant found"
+    (Of_sexp_error
+     (Dunolint.Sexp_helpers.Error_context.E
+      ("Unknown construct [unknown]."
+       (did_you_mean? ((var unknown) (candidates = > >= < <= !=)))))
      (invalid_sexp (unknown 3.17)))
     |}];
   ()

--- a/test/dunolint-lib/test__dunolint0__dunolint_lang_version.ml
+++ b/test/dunolint-lib/test__dunolint0__dunolint_lang_version.ml
@@ -143,7 +143,9 @@ let%expect_test "Predicate.t_of_sexp" =
   [%expect
     {|
     (Of_sexp_error
-     "dunolint_lang_version.t_of_sexp: polymorphic variant tag takes an argument"
+     (Dunolint.Sexp_helpers.Error_context.E
+      ("The construct [=] expects one or more arguments."
+       (suggestion "Replace by: (= ARG)")))
      (invalid_sexp =))
     |}];
   test "(= 1.0 extra)";
@@ -156,7 +158,10 @@ let%expect_test "Predicate.t_of_sexp" =
   test "(unknown 1.0)";
   [%expect
     {|
-    (Of_sexp_error "dunolint_lang_version.t_of_sexp: no matching variant found"
+    (Of_sexp_error
+     (Dunolint.Sexp_helpers.Error_context.E
+      ("Unknown construct [unknown]."
+       (did_you_mean? ((var unknown) (candidates = > >= < <= !=)))))
      (invalid_sexp (unknown 1.0)))
     |}];
   ()

--- a/test/dunolint-lib/test__sexp_helpers.ml
+++ b/test/dunolint-lib/test__sexp_helpers.ml
@@ -64,28 +64,38 @@ let%expect_test "parse_variant" =
   [%expect
     {|
     (Of_sexp_error
-     "test_predicate_of_sexp: polymorphic variant tag takes an argument"
+     (Dunolint.Sexp_helpers.Error_context.E
+      ("The construct [foo] expects one or more arguments."
+       (suggestion "Replace by: (foo ARG)")))
      (invalid_sexp foo))
     |}];
   test "bar";
   [%expect
     {|
     (Of_sexp_error
-     "test_predicate_of_sexp: polymorphic variant tag takes an argument"
+     (Dunolint.Sexp_helpers.Error_context.E
+      ("The construct [bar] expects one or more arguments."
+       (suggestion "Replace by: (bar ARG)")))
      (invalid_sexp bar))
     |}];
   (* Error: atom that doesn't match any predicate. *)
   test "unknown";
   [%expect
     {|
-    (Of_sexp_error "test_predicate_of_sexp: no matching variant found"
+    (Of_sexp_error
+     (Dunolint.Sexp_helpers.Error_context.E
+      ("Unknown construct [unknown]."
+       (did_you_mean? ((var unknown) (candidates foo bar nullary ctx variadic)))))
      (invalid_sexp unknown))
     |}];
   (* Error: list with atom that doesn't match. *)
   test "(unknown hello)";
   [%expect
     {|
-    (Of_sexp_error "test_predicate_of_sexp: no matching variant found"
+    (Of_sexp_error
+     (Dunolint.Sexp_helpers.Error_context.E
+      ("Unknown construct [unknown]."
+       (did_you_mean? ((var unknown) (candidates foo bar nullary ctx variadic)))))
      (invalid_sexp (unknown hello)))
     |}];
   (* Error: list with wrong number of arguments (zero). *)
@@ -154,7 +164,9 @@ let%expect_test "parse_variant" =
   [%expect
     {|
     (Of_sexp_error
-     "test_predicate_of_sexp: polymorphic variant tag takes an argument"
+     (Dunolint.Sexp_helpers.Error_context.E
+      ("The construct [ctx] expects one or more arguments."
+       (suggestion "Replace by: (ctx ARG)")))
      (invalid_sexp ctx))
     |}];
   (* Success: variadic variant with arguments. *)
@@ -168,7 +180,9 @@ let%expect_test "parse_variant" =
   [%expect
     {|
     (Of_sexp_error
-     "test_predicate_of_sexp: polymorphic variant tag takes an argument"
+     (Dunolint.Sexp_helpers.Error_context.E
+      ("The construct [variadic] expects one or more arguments."
+       (suggestion "Replace by: (variadic ARG)")))
      (invalid_sexp variadic))
     |}];
   ()


### PR DESCRIPTION
This pr defines a way to embed more context to sexp errors that we'll be able to further extend as we see fit. We improve a few cases of errors with it to illustrate.