### PR TITLE
Add support for DUNE_ROOT environment variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Add support for `DUNE_ROOT` environment variable (#156, @mbarbin).
 - Add initial support for linting `dune-workspace` files (#153, @mbarbin).
 - Add initial support for linting `dunolint` files (#146, @mbarbin).
 - Enabled OCaml `5.4` in CI (#136, @mbarbin).

--- a/doc/docs/explanation/workspace-root.md
+++ b/doc/docs/explanation/workspace-root.md
@@ -23,6 +23,19 @@ $ dunolint lint --root=/path/to/project
 
 This is the same flag that Dune uses, maintaining consistency between the tools.
 
+### The `DUNE_ROOT` Environment Variable
+
+As an alternative to the `--root` flag, you can set the `DUNE_ROOT` environment variable:
+
+<!-- $MDX skip -->
+```bash
+$ DUNE_ROOT=/path/to/project dunolint lint
+```
+
+This is useful for scripting scenarios or when you want to set the root once for multiple commands. Both absolute paths and paths relative to `cwd` are supported.
+
+**Precedence:** The `--root` flag takes precedence over the `DUNE_ROOT` environment variable.
+
 ## Working Directory Change
 
 Once the workspace root is determined, Dunolint changes its working directory to that root before performing any operations. This ensures:

--- a/test/cram/env-dune-root.t
+++ b/test/cram/env-dune-root.t
@@ -1,0 +1,39 @@
+Test the DUNE_ROOT environment variable and its interaction with --root.
+
+Setup two separate workspaces:
+
+  $ mkdir workspace-a
+  $ touch workspace-a/dune-project
+
+  $ mkdir workspace-b
+  $ touch workspace-b/dune-project
+
+Without DUNE_ROOT, auto-detection finds workspace-a:
+
+  $ (cd workspace-a && dunolint tools find-workspace-root)
+  $TESTCASE_ROOT/workspace-a
+
+DUNE_ROOT overrides auto-detection to use workspace-b instead:
+
+  $ (cd workspace-a && DUNE_ROOT=../workspace-b dunolint tools find-workspace-root)
+  $TESTCASE_ROOT/workspace-b
+
+The --root flag takes precedence over DUNE_ROOT:
+
+  $ (cd workspace-a && DUNE_ROOT=../workspace-b dunolint tools find-workspace-root --root .)
+  $TESTCASE_ROOT/workspace-a/
+
+Invalid DUNE_ROOT and --root values are rejected with a user-friendly error:
+
+  $ DUNE_ROOT="" dunolint tools find-workspace-root
+  Error: Invalid value for [DUNE_ROOT] environment variable.
+  "": invalid path
+  [124]
+
+  $ dunolint tools find-workspace-root --root '' 2> output
+  [124]
+
+  $ grep '^dunolint: ' output
+  dunolint: option '--root': "": invalid path
+
+  $ rm output


### PR DESCRIPTION
Allow users to specify the workspace root via the DUNE_ROOT environment variable as an alternative to the --root flag. The --root flag takes precedence when both are specified.

Fixes #114 