### PR TITLE
Use cache-readonly to optimize GitHub Actions cache usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,12 @@ jobs:
           echo "DUNE_WORKSPACE=$PWD/dune-workspace-${{ matrix.ocaml-version }}" >> "$GITHUB_ENV"
 
       - name: Setup Dune
-        uses: mbarbin/setup-dune@d38f7c80df59974cbe417c7f2a849219d54b4fdf # v2.0.0+patch-3
+        uses: mbarbin/setup-dune@ae2985bcdedc6fb24e5743d6f9dace9cf262b41c # v2.0.0+patch-4
         with:
           version: "3.21.0"
           workspace: ${{ env.DUNE_WORKSPACE }}
           cache-prefix: "main-ci-${{ matrix.ocaml-version }}"
+          cache-readonly: ${{ github.ref != 'refs/heads/main' }}
           steps: install-dune enable-pkg lazy-update-depexts install-gpatch install-depexts
 
       # Setting implicit_transitive_deps based on the compiler version.

--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -41,11 +41,12 @@ jobs:
           echo "DUNE_WORKSPACE=$PWD/dune-workspace-${{ env.OCAML_VERSION }}" >> "$GITHUB_ENV"
 
       - name: Setup Dune
-        uses: mbarbin/setup-dune@d38f7c80df59974cbe417c7f2a849219d54b4fdf # v2.0.0+patch-3
+        uses: mbarbin/setup-dune@ae2985bcdedc6fb24e5743d6f9dace9cf262b41c # v2.0.0+patch-4
         with:
           version: "3.21.0"
           workspace: ${{ env.DUNE_WORKSPACE }}
-          cache-prefix: "deploy-doc-${{ env.OCAML_VERSION }}"
+          cache-prefix: "main-ci-${{ env.OCAML_VERSION }}"
+          cache-readonly: true
           steps: install-dune enable-pkg lazy-update-depexts install-gpatch install-depexts
 
       - name: Build Odoc Pages

--- a/.github/workflows/dune-pkg-more-ci.yml
+++ b/.github/workflows/dune-pkg-more-ci.yml
@@ -56,11 +56,12 @@ jobs:
           fi
 
       - name: Setup Dune
-        uses: mbarbin/setup-dune@d38f7c80df59974cbe417c7f2a849219d54b4fdf # v2.0.0+patch-3
+        uses: mbarbin/setup-dune@ae2985bcdedc6fb24e5743d6f9dace9cf262b41c # v2.0.0+patch-4
         with:
           version: "3.21.0"
           workspace: ${{ env.DUNE_WORKSPACE }}
           cache-prefix: ${{ matrix.ocaml-version }}
+          cache-readonly: ${{ github.ref != 'refs/heads/main' }}
           only-packages: ${{ env.PACKAGES }}
           steps: install-dune enable-pkg lazy-update-depexts install-gpatch install-depexts
 

--- a/.github/workflows/test-deploy-doc.yml
+++ b/.github/workflows/test-deploy-doc.yml
@@ -41,11 +41,12 @@ jobs:
           echo "DUNE_WORKSPACE=$PWD/dune-workspace-${{ env.OCAML_VERSION }}" >> "$GITHUB_ENV"
 
       - name: Setup Dune
-        uses: mbarbin/setup-dune@d38f7c80df59974cbe417c7f2a849219d54b4fdf # v2.0.0+patch-3
+        uses: mbarbin/setup-dune@ae2985bcdedc6fb24e5743d6f9dace9cf262b41c # v2.0.0+patch-4
         with:
           version: "3.21.0"
           workspace: ${{ env.DUNE_WORKSPACE }}
-          cache-prefix: "deploy-doc-${{ env.OCAML_VERSION }}"
+          cache-prefix: "main-ci-${{ env.OCAML_VERSION }}"
+          cache-readonly: true
           steps: install-dune enable-pkg lazy-update-depexts install-gpatch install-depexts
 
       - name: Build Odoc Pages


### PR DESCRIPTION
Update all workflows to use setup-dune v2.0.0+patch-4 which adds the new `cache-readonly` input. This helps prevent cache eviction issues where PR caches can accumulate and evict the main branch cache.

Changes:
- ci.yml: PRs restore cache read-only, only main branch saves
- dune-pkg-more-ci.yml: Same strategy as ci.yml
- deploy-doc.yml: Always read-only, reuses main-ci cache
- test-deploy-doc.yml: Always read-only, reuses main-ci cache

Expected outcome:
- Reduced cache storage usage (no separate deploy-doc caches)
- Main branch caches are preserved (PRs don't evict them)
- PRs still benefit from cache restoration for faster builds
- Only ci.yml and dune-pkg-more-ci.yml on main branch write caches