### PR TITLE
Make some libraries internal

### DIFF
--- a/dunolint
+++ b/dunolint
@@ -41,13 +41,20 @@
 (rule
  (cond
   ((path (glob src/dunolint-lib/vendor/**))
-   (enforce (dune (library (public_name (is_prefix dunolint-lib.))))))
+   (enforce
+    (dune
+     (library
+      (or (public_name (is_prefix dunolint-lib.))
+       (package (equals dunolint-lib)))))))
   ((path (glob src/dunolint-lib/dunolint/*))
    (enforce (dune (library (public_name (equals dunolint-lib))))))
   ((path (glob src/dunolint-lib-base/**))
    (enforce (dune (library (public_name (equals dunolint-lib-base))))))
   ((path (or (glob src/dunolint/**) (glob src/stdlib/**)))
-   (enforce (dune (library (public_name (is_prefix dunolint.))))))
+   (enforce
+    (dune
+     (library
+      (or (public_name (is_prefix dunolint.)) (package (equals dunolint)))))))
   (true
    (enforce
     (dune (library (if_present (public_name (is_prefix dunolint-dev.)))))))))

--- a/dunolint-config/src/config.ml
+++ b/dunolint-config/src/config.ml
@@ -75,7 +75,7 @@ let () =
 let () =
   (* Under [test/] and [dunolint-config/] we prefer using the [(package _)]
      stanza rather than having public names that are not going to be used by any
-     depending code. All these libraries belong to [dunolint-tests]. *)
+     depending code. All these libraries are tests internals. *)
   rule
     (cond
        [ ( path (glob "test/dunolint-lib-base/*")

--- a/dunolint-config/src/config.ml
+++ b/dunolint-config/src/config.ml
@@ -98,10 +98,21 @@ let () =
 ;;
 
 let () =
+  (* Libraries under [src/] either expose themselves publicly through a prefixed
+     [public_name] or remain private to their package via a [(package _)] field.
+     The rules below accept either shape so that sub-libraries which are not
+     part of dunolint's public API (and therefore not exposed once the package
+     is installed) can opt out of having a [public_name]. *)
   rule
     (cond
        [ ( path (glob "src/dunolint-lib/vendor/**")
-         , enforce (dune (library (public_name (is_prefix "dunolint-lib.")))) )
+         , enforce
+             (dune
+                (library
+                   (or_
+                      [ public_name (is_prefix "dunolint-lib.")
+                      ; package (equals (Dune.Package.Name.v "dunolint-lib"))
+                      ]))) )
        ; ( path (glob "src/dunolint-lib/dunolint/*")
          , enforce
              (dune
@@ -114,7 +125,13 @@ let () =
                    (public_name (equals (Dune.Library.Public_name.v "dunolint-lib-base")))))
          )
        ; ( path (or_ [ glob "src/dunolint/**"; glob "src/stdlib/**" ])
-         , enforce (dune (library (public_name (is_prefix "dunolint.")))) )
+         , enforce
+             (dune
+                (library
+                   (or_
+                      [ public_name (is_prefix "dunolint.")
+                      ; package (equals (Dune.Package.Name.v "dunolint"))
+                      ]))) )
        ; ( true_
          , enforce
              (dune (library (if_present (`public_name (is_prefix "dunolint-dev."))))) )

--- a/src/dunolint-lib-base/dune
+++ b/src/dunolint-lib-base/dune
@@ -2,11 +2,7 @@
  (name dunolint_base)
  (public_name dunolint-lib-base)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Base)
- (libraries
-  base
-  dunolint-lib
-  dunolint-lib.vendor_blang
-  dunolint-lib.vendor_vcs)
+ (libraries base dunolint-lib dunolint_vendor_blang dunolint_vendor_vcs)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/src/dunolint-lib/dunolint/dune
+++ b/src/dunolint-lib/dunolint/dune
@@ -11,12 +11,7 @@
   Sexplib0
   -open
   Sexplib0.Sexp_conv)
- (libraries
-  dunolint-lib.vendor_blang
-  dunolint-lib.vendor_vcs
-  dyn
-  re
-  sexplib0)
+ (libraries dunolint_vendor_blang dunolint_vendor_vcs dyn re sexplib0)
  (modules
   (:standard \ stdlib_compat4xx stdlib_compat5xx))
  (instrumentation

--- a/src/dunolint-lib/vendor/blang/dune
+++ b/src/dunolint-lib/vendor/blang/dune
@@ -1,6 +1,6 @@
 (library
  (name dunolint_vendor_blang)
- (public_name dunolint-lib.vendor_blang)
+ (package dunolint-lib)
  (wrapped false)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Sexplib0)
  (libraries sexplib0))

--- a/src/dunolint/dunolint_cli/dune
+++ b/src/dunolint/dunolint_cli/dune
@@ -1,6 +1,6 @@
 (library
  (name dunolint_cli)
- (public_name dunolint.dunolint_cli)
+ (package dunolint)
  (flags
   :standard
   -w
@@ -20,12 +20,12 @@
  (libraries
   cmdlang
   dunolint-lib
-  dunolint.dune_linter
-  dunolint.dune_project_linter
-  dunolint.dune_workspace_linter
-  dunolint.dunolint_engine
-  dunolint.dunolint_linter
-  dunolint.dunolinter
+  dune_linter
+  dune_project_linter
+  dune_workspace_linter
+  dunolint_engine
+  dunolint_linter
+  dunolinter
   dunolint_stdlib
   parsexp
   pplumbing-log

--- a/src/dunolint/dunolint_cli/dune
+++ b/src/dunolint/dunolint_cli/dune
@@ -19,14 +19,14 @@
   Dunolint.Std)
  (libraries
   cmdlang
-  dunolint-lib
   dune_linter
   dune_project_linter
   dune_workspace_linter
+  dunolint-lib
   dunolint_engine
   dunolint_linter
-  dunolinter
   dunolint_stdlib
+  dunolinter
   parsexp
   pplumbing-log
   pplumbing-log-cli

--- a/src/dunolint/dunolint_engine/dune
+++ b/src/dunolint/dunolint_engine/dune
@@ -18,10 +18,10 @@
  (libraries
   cmdlang
   dunolint-lib
-  dunolint.dune_linter
-  dunolint.dune_project_linter
-  dunolint.dunolinter
-  dunolint.vendor_prompt
+  dune_linter
+  dune_project_linter
+  dunolinter
+  dunolint_vendor_prompt
   dunolint_stdlib
   file-rewriter
   logs

--- a/src/dunolint/dunolint_engine/dune
+++ b/src/dunolint/dunolint_engine/dune
@@ -17,12 +17,12 @@
   Dunolint.Std)
  (libraries
   cmdlang
-  dunolint-lib
   dune_linter
   dune_project_linter
-  dunolinter
-  dunolint_vendor_prompt
+  dunolint-lib
   dunolint_stdlib
+  dunolint_vendor_prompt
+  dunolinter
   file-rewriter
   logs
   pageantty.git-pager

--- a/src/dunolint/vendor/prompt/dune
+++ b/src/dunolint/vendor/prompt/dune
@@ -1,6 +1,6 @@
 (library
  (name dunolint_vendor_prompt)
- (public_name dunolint.vendor_prompt)
+ (package dunolint)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Cmdlang)
  (libraries cmdlang fmt)
  (lint

--- a/src/stdlib/dune
+++ b/src/stdlib/dune
@@ -1,6 +1,6 @@
 (library
  (name dunolint_stdlib)
- (public_name dunolint.stdlib)
+ (package dunolint)
  (flags
   :standard
   -w

--- a/test/dunolint/dunolint_linter/dune
+++ b/test/dunolint/dunolint_linter/dune
@@ -14,7 +14,7 @@
   Dunolint.Std)
  (libraries
   dunolint
-  dunolint.dunolint_linter
+  dunolint_linter
   dunolint_stdlib
   dunolinter
   file-rewriter


### PR DESCRIPTION
This change is proposed under the understanding that changing `(pubic_name PKG.*)` into `(package PKG)` make the lib private to said package.

The goal is to reduce the user facing surface.